### PR TITLE
Updating Combo Scaler to IQR

### DIFF
--- a/src/sat_tile_stack/utils.py
+++ b/src/sat_tile_stack/utils.py
@@ -46,11 +46,11 @@ import json, numpy as np
 
 #     return scaled.astype(dtype)
 
-def combo_scaler(x, range_max=1):
+def combo_scaler(x, p2=75, p1=25, range_max=1):
     x = np.asarray(x)
     with np.errstate(all="ignore"):
         median_x = np.nanmedian(x)
-        iqr = np.nanpercentile(x, 95) - np.nanpercentile(x, 5)
+        iqr = np.nanpercentile(x, p2) - np.nanpercentile(x, p1)
         robust = (x - median_x) / iqr
         mn, mx = np.nanmin(robust), np.nanmax(robust)
         scaled = (robust - mn) / (mx - mn) * range_max


### PR DESCRIPTION
Hey @jharlanr! 

This is a super cool package!

I made a potential change to the combo scaler in #4271d3c, to limit the percentiles in the scaling to the interquartile range since it allows the scaling statistics to be calculated on the central tendency, uninfluenced by outliers. When run on a channel by channel basis, this is really helpful in setting each feature to have similar variances, even if one of them has outliers, allowing more efficient learning.

In the spirit of the previous function, I also added kwargs to provide some flexibility in case there is a scene that requires special attention to outlying reflectance values across channels, so the user can choose if needed