### PR TITLE
major update for cf-compliance

### DIFF
--- a/engine/stacking/build_stacks.py
+++ b/engine/stacking/build_stacks.py
@@ -36,7 +36,16 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 import pystac_client
 import planetary_computer
 
-from sat_tile_stack import sattile_stack, write_netcdf_from_da
+from sat_tile_stack import sattile_stack, write_netcdf
+from sat_tile_stack.coregister import (
+    add_scalar_series, add_static_polygon, add_ndwi_from_stack,
+)
+
+# Variables a fully-built v2 per-lake file must contain (used by _validate_nc
+# so a resubmitted job rebuilds partially-written / pre-coregister files).
+V2_REQUIRED_VARS = (
+    "reflectance", "cloud_mask", "p_water", "lake_boundary", "water_mask_ndwi",
+)
 
 
 def parse_args():
@@ -54,7 +63,7 @@ def parse_args():
     parser.add_argument("--time_range", type=str, required=True,
                         help="Time range YYYY-MM-DD/YYYY-MM-DD")
     parser.add_argument("--bands", nargs="+",
-                        default=["B04", "B03", "B02", "B08", "B11", "SCL"],
+                        default=["B04", "B03", "B02", "B08", "B11", "B12", "SCL"],
                         help="Band names to include")
     parser.add_argument("--collection", type=str, default="sentinel-2-l2a",
                         help="STAC collection ID")
@@ -70,6 +79,17 @@ def parse_args():
                         help="Starting row index")
     parser.add_argument("--count", type=int, default=None,
                         help="Number of rows to process (None = all)")
+    # --- Stage-2 coregister (single end-to-end per-lake, in place) ---
+    parser.add_argument("--coregister", action="store_true",
+                        help="After build, add p_water + lake_boundary + "
+                             "water_mask_ndwi in place (one .nc per lake)")
+    parser.add_argument("--dunmire_nc", type=str, default=None,
+                        help="Dunmire all_lakes_<YEAR>.nc (p_water source)")
+    parser.add_argument("--boundary_geojson", type=str, default=None,
+                        help="Dunmire labels_<YEAR>_volumes.geojson "
+                             "(lake_boundary polygons)")
+    parser.add_argument("--ndwi_min", type=float, default=0.3,
+                        help="NDWI water threshold (Dunmire 2021/2025: 0.3)")
     return parser.parse_args()
 
 
@@ -77,26 +97,32 @@ MAX_RETRIES = 3
 RETRY_DELAY = 10  # seconds
 
 
-def _validate_nc(filepath, expected_tile_size):
-    """Quick check if an existing .nc file is complete. Only reads metadata, not data."""
+def _validate_nc(filepath, expected_tile_size, require_coreg=False):
+    """Quick check if an existing .nc file is complete. Only reads metadata.
+
+    When ``require_coreg`` is set (end-to-end mode), a file missing any of the
+    coregistered v2 variables is treated as incomplete so a resubmitted job
+    rebuilds it rather than skipping a stage-1-only leftover.
+    """
     try:
         import xarray as xr
         ds = xr.open_dataset(str(filepath))
-        if "reflectance" not in ds:
+        try:
+            if "reflectance" not in ds:
+                return False
+            da = ds["reflectance"]
+            if da.sizes.get("time", 0) == 0:
+                return False
+            if (da.sizes.get("y", 0) < expected_tile_size
+                    or da.sizes.get("x", 0) < expected_tile_size):
+                return False
+            if "band" not in ds.coords:
+                return False
+            if require_coreg and any(v not in ds for v in V2_REQUIRED_VARS):
+                return False
+            return True
+        finally:
             ds.close()
-            return False
-        da = ds["reflectance"]
-        if da.sizes.get("time", 0) == 0:
-            ds.close()
-            return False
-        if da.sizes.get("y", 0) < expected_tile_size or da.sizes.get("x", 0) < expected_tile_size:
-            ds.close()
-            return False
-        if "band" not in ds.coords:
-            ds.close()
-            return False
-        ds.close()
-        return True
     except Exception:
         return False
 
@@ -110,9 +136,12 @@ def build_one_stack(task):
     lake_id, lon, lat, args_dict = task
     outfile = Path(args_dict["output_dir"]) / f"{lake_id}.nc"
 
-    # Check if file exists AND is valid
+    coregister = args_dict.get("coregister", False)
+
+    # Check if file exists AND is valid (full v2 set when coregistering)
     if outfile.exists():
-        if _validate_nc(outfile, args_dict["tile_size"]):
+        if _validate_nc(outfile, args_dict["tile_size"],
+                        require_coreg=coregister):
             return {"status": "skip", "id": lake_id}
         else:
             outfile.unlink()  # corrupted/incomplete — delete and rebuild
@@ -146,7 +175,35 @@ def build_one_stack(task):
                 _sys.stdout = _old_stdout
                 _sys.stderr = _old_stderr
 
-            write_netcdf_from_da(stack, str(outfile))
+            # stack is now an xarray.Dataset (reflectance + cloud_mask);
+            # write_netcdf finalizes CF-1.8 and auto-detects spatial vars.
+            write_netcdf(stack, str(outfile))
+
+            # Stage-2: coregister the ancillary layers IN PLACE (atomic
+            # temp+rename, output == input) — one .nc per lake, identical
+            # to the verification notebook. Deterministic, no network.
+            if coregister:
+                op = str(outfile)
+                _so, _se = _sys.stdout, _sys.stderr
+                _sys.stdout = _io.StringIO()
+                _sys.stderr = _io.StringIO()
+                try:
+                    add_scalar_series(
+                        op, op, source_nc=args_dict["dunmire_nc"],
+                        source_var="S2_water", lake_id=lake_id,
+                        target_var="p_water",
+                    )
+                    add_static_polygon(
+                        op, op, geojson=args_dict["boundary_geojson"],
+                        lake_id=lake_id, target_var="lake_boundary",
+                    )
+                    add_ndwi_from_stack(
+                        op, op, ndwi_min=args_dict["ndwi_min"],
+                        target_var="water_mask_ndwi",
+                    )
+                finally:
+                    _sys.stdout, _sys.stderr = _so, _se
+
             return {"status": "ok", "id": lake_id}
 
         except Exception as e:
@@ -185,6 +242,17 @@ def main():
     print(f"Workers:    {args.workers}")
     print(f"{'='*60}\n", flush=True)
 
+    if args.coregister:
+        missing = [n for n, v in (("--dunmire_nc", args.dunmire_nc),
+                                   ("--boundary_geojson", args.boundary_geojson))
+                   if not v]
+        if missing:
+            raise SystemExit(f"--coregister requires {', '.join(missing)}")
+        print(f"Coregister: ON  (one .nc/lake, in place)")
+        print(f"  p_water  <- {args.dunmire_nc}")
+        print(f"  boundary <- {args.boundary_geojson}")
+        print(f"  ndwi_min  = {args.ndwi_min}", flush=True)
+
     # Build task list
     args_dict = {
         "output_dir": str(output_dir),
@@ -194,6 +262,10 @@ def main():
         "pix_res": args.pix_res,
         "tile_size": args.tile_size,
         "cloudmask": args.cloudmask,
+        "coregister": args.coregister,
+        "dunmire_nc": args.dunmire_nc,
+        "boundary_geojson": args.boundary_geojson,
+        "ndwi_min": args.ndwi_min,
     }
 
     tasks = [

--- a/engine/stacking/run_build_stacks.sh
+++ b/engine/stacking/run_build_stacks.sh
@@ -59,7 +59,7 @@ python3 -u "$REPO_DIR/engine/stacking/build_stacks.py" \
     --output_dir "$SHERLOCK_DIR/stacks/CW_2018" \
     --id_col "new_id" \
     --time_range "2018-05-01/2018-09-30" \
-    --bands B04 B03 B02 B08 B11 SCL \
+    --bands B04 B03 B02 B08 B11 B12 SCL \
     --pix_res 10 \
     --tile_size 512 \
     --cloudmask scl \
@@ -94,7 +94,7 @@ python3 -u "$REPO_DIR/engine/stacking/build_stacks.py" \
     --output_dir "$SHERLOCK_DIR/stacks/CW_2018" \
     --id_col "new_id" \
     --time_range "2018-05-01/2018-09-30" \
-    --bands B04 B03 B02 B08 B11 SCL \
+    --bands B04 B03 B02 B08 B11 B12 SCL \
     --pix_res 10 \
     --tile_size 512 \
     --cloudmask scl \

--- a/engine/stacking/run_build_stacks_region.sh
+++ b/engine/stacking/run_build_stacks_region.sh
@@ -55,7 +55,13 @@ fi
 REPO_DIR="/oak/stanford/groups/cyaolai/JoshRines/repos/sat-tile-stack"
 SHERLOCK_DIR="/oak/stanford/groups/cyaolai/JoshRines/sherlock/sherlock_sattilestack"
 DUNMIRE_GEOJSON="$REPO_DIR/labeling/dunmire/labels_${YEAR}_volumes.geojson"
-OUTPUT_DIR="$SHERLOCK_DIR/stacks/${REGION}_${YEAR}"
+# Dunmire 2025 per-lake daily series (p_water source). CONFIRM/EDIT this path
+# on Sherlock before submitting — must contain an `ids` coord with this
+# region's lake IDs and an `S2_water` variable.
+DUNMIRE_NC="$SHERLOCK_DIR/dunmire/all_lakes_${YEAR}.nc"
+# v2 CF-1.8 rebuild lands in a fresh tree; v1 stacks/ stays untouched as a
+# fallback until v2 passes validation (see sat-tile-stack/claudiary/20260508F).
+OUTPUT_DIR="$SHERLOCK_DIR/stacks_v2/${REGION}_${YEAR}"
 EXTRACT_CSV="$SHERLOCK_DIR/stacks/${REGION}_${YEAR}_centroids.csv"
 
 mkdir -p "$SHERLOCK_DIR/logs"
@@ -68,8 +74,20 @@ echo "Region:     $REGION"
 echo "Year:       $YEAR"
 echo "GeoJSON:    $DUNMIRE_GEOJSON"
 echo "Output:     $OUTPUT_DIR"
+echo "DunmireNC:  $DUNMIRE_NC"
 echo "CPUs:       ${SLURM_CPUS_PER_TASK:-1}"
 echo "=============================================="
+
+# --- Pre-flight: fail fast on missing coregister inputs (don't waste an
+#     overnight build only to have every lake's coregister step error). ---
+for f in "$DUNMIRE_GEOJSON" "$DUNMIRE_NC"; do
+    if [ ! -f "$f" ]; then
+        echo "ERROR: required coregister input not found: $f"
+        echo "Edit DUNMIRE_NC / DUNMIRE_GEOJSON in this script (or stage the"
+        echo "file) before submitting. Aborting."
+        exit 1
+    fi
+done
 
 # --- Load modules ---
 ml system
@@ -78,7 +96,12 @@ ml py-numpy/1.26.3_py312
 ml py-pandas/2.2.1_py312
 ml py-scipy/1.12.0_py312
 
-pip install --user xarray netcdf4 pystac-client planetary-computer stackstac geopandas rioxarray pyproj shapely matplotlib dask
+# numpy/pandas/scipy come from the Sherlock modules above (pip-installing
+# them would conflict). rasterio is explicit (add_static_polygon needs
+# rasterio.features/warp; don't rely on it being transitive); zarr is
+# harmless + future-proofs add_raster_zarr.
+pip install --user xarray netcdf4 pystac-client planetary-computer stackstac \
+    geopandas rioxarray pyproj shapely rasterio "zarr>=3" matplotlib dask
 
 export PYTHONPATH="$REPO_DIR:$PYTHONPATH"
 
@@ -142,12 +165,16 @@ python3 -u "$REPO_DIR/engine/stacking/build_stacks.py" \
     --output_dir "$OUTPUT_DIR" \
     --id_col "new_id" \
     --time_range "${YEAR}-05-01/${YEAR}-09-30" \
-    --bands B04 B03 B02 B08 B11 SCL \
+    --bands B04 B03 B02 B08 B11 B12 SCL \
     --pix_res 10 \
     --tile_size 512 \
     --cloudmask scl \
     --workers 1 \
-    --count 1
+    --count 1 \
+    --coregister \
+    --dunmire_nc "$DUNMIRE_NC" \
+    --boundary_geojson "$DUNMIRE_GEOJSON" \
+    --ndwi_min 0.3
 
 # Inspect the first file
 FIRST_NC=$(ls "$OUTPUT_DIR/"*.nc 2>/dev/null | head -1)
@@ -177,11 +204,15 @@ python3 -u "$REPO_DIR/engine/stacking/build_stacks.py" \
     --output_dir "$OUTPUT_DIR" \
     --id_col "new_id" \
     --time_range "${YEAR}-05-01/${YEAR}-09-30" \
-    --bands B04 B03 B02 B08 B11 SCL \
+    --bands B04 B03 B02 B08 B11 B12 SCL \
     --pix_res 10 \
     --tile_size 512 \
     --cloudmask scl \
-    --workers 8
+    --workers 8 \
+    --coregister \
+    --dunmire_nc "$DUNMIRE_NC" \
+    --boundary_geojson "$DUNMIRE_GEOJSON" \
+    --ndwi_min 0.3
 
 EXIT_CODE=$?
 

--- a/engine/validation/cf_check.py
+++ b/engine/validation/cf_check.py
@@ -1,0 +1,7 @@
+"""CLI shim — real logic in sat_tile_stack.cf_check."""
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+from sat_tile_stack.cf_check import main
+
+if __name__ == "__main__":
+    main()

--- a/environment.yml
+++ b/environment.yml
@@ -6,16 +6,23 @@ channels:
 # Conda handles only:
 #   - the Python interpreter
 #   - non-Python tools (ffmpeg)
+#   - the standard CF-1.8 validator (cfchecker) which needs the UDUNITS2
+#     system library — conda-forge bundles it so it works out of the box
+#     (pip users instead: `pip install .[validation]` + system UDUNITS2)
 #   - dev conveniences (jupyterlab, ipykernel)
 #
-# All Python package deps come from pyproject.toml via `pip install -e .[dev]`
-# at the bottom. That keeps a single source of truth — no duplicate dep lists.
+# All other Python package deps come from pyproject.toml via
+# `pip install -e .[dev]` at the bottom — single source of truth, no
+# duplicate dep lists.
 
 dependencies:
   - python>=3.9
   - pip
   # non-Python tools
   - ffmpeg
+  # standard CF-1.8 validator (brings UDUNITS2); powers sts-cf-check &
+  # the cfchecker path in cf_check.py / verify notebooks
+  - cfchecker
   # dev conveniences
   - jupyterlab
   - ipykernel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
   "rioxarray",
   "matplotlib",
   "dask[complete]",
+  "pystac",
   "pystac-client",
   "planetary-computer",
   "rasterio",
@@ -25,6 +26,7 @@ dependencies = [
   "shapely",
   "netcdf4",
   "scipy",
+  "zarr>=3",
 ]
 
 [project.optional-dependencies]
@@ -37,9 +39,13 @@ dev = [
 labeling = [
   "flask",
 ]
+validation = [
+  "cfchecker",
+]
 
 [project.scripts]
 lakelabel = "sat_tile_stack.labeling:main"
+sts-cf-check = "sat_tile_stack.cf_check:main"
 
 [tool.setuptools]
 packages = ["sat_tile_stack"]

--- a/sat_tile_stack/__init__.py
+++ b/sat_tile_stack/__init__.py
@@ -6,7 +6,16 @@ from .stack import sattile_stack
 from .bounds import sat_mask_array, bounds_latlon_around, best_crs_for_point, pctnanpix_inmask, pctcloudypix_inmask
 from .io import scrub_attrs, sanitise_dataset, coerce_attrs_to_json_safe, write_netcdf_from_da, write_netcdf, finalize_cf, export_geotiff
 from .visualize import timestack_to_movie, export_frame, multi_panel_frame, batch_movies
-from .utils import combo_scaler, cloud_pix_mask
+from .utils import combo_scaler, cloud_pix_mask, SCL_CLOUDY_CLASSES
+from .coregister import (
+    add_raster_zarr, add_ndwi_mask, add_ndwi_from_stack,
+    add_static_polygon, add_scalar_series,
+)
+# NB: import the batch fn under an alias — a bare `cf_check` here would
+# shadow the `sat_tile_stack.cf_check` submodule (same name) and break
+# `import sat_tile_stack.cf_check`.
+from .cf_check import quick_cf_audit, check_file
+from .cf_check import cf_check as cf_check_paths
 from .append import append_band, append_timeseries, append_metadata
 from .ids import FeatureTracker
 
@@ -15,7 +24,10 @@ __all__ = [
     "sat_mask_array", "bounds_latlon_around", "best_crs_for_point", "pctnanpix_inmask", "pctcloudypix_inmask",
     "scrub_attrs", "sanitise_dataset", "coerce_attrs_to_json_safe", "write_netcdf_from_da", "write_netcdf", "finalize_cf", "export_geotiff",
     "timestack_to_movie", "export_frame", "multi_panel_frame", "batch_movies",
-    "combo_scaler", "cloud_pix_mask",
+    "combo_scaler", "cloud_pix_mask", "SCL_CLOUDY_CLASSES",
+    "add_raster_zarr", "add_ndwi_mask", "add_ndwi_from_stack",
+    "add_static_polygon", "add_scalar_series",
+    "quick_cf_audit", "check_file", "cf_check_paths",
     "append_band", "append_timeseries", "append_metadata",
     "FeatureTracker",
 ]

--- a/sat_tile_stack/cf_check.py
+++ b/sat_tile_stack/cf_check.py
@@ -1,0 +1,256 @@
+"""
+CF-1.8 compliance checking for the v2 per-lake stacks.
+
+Two layers:
+
+* ``quick_cf_audit(path)`` — a fast, **dependency-free** structural audit that
+  asserts the CF things this pipeline must get right (Conventions, the scalar
+  ``crs`` grid-mapping variable + ``grid_mapping`` on every spatial var, x/y/
+  time coordinate attrs, flag-variable ``flag_values``/``flag_meanings``
+  consistency, ``water_mask_ndwi`` ``_FillValue``). Always available; catches
+  the regressions we actually introduce.
+
+* ``check_file`` / ``cf_check`` — the **authoritative** CF checker
+  (`cfchecker`, ``cfchecks`` CLI, ``--version 1.8``). Requires the optional
+  ``cfchecker`` dependency (``conda install -c conda-forge cfchecker``); the
+  structural audit is the fallback when it is not installed.
+
+CLI: ``sts-cf-check <file-or-dir> ...`` (exits 0 iff all clean).
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import re
+import shutil
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+import xarray as xr
+
+
+# ---------------------------------------------------------------------------
+# Dependency-free structural audit
+# ---------------------------------------------------------------------------
+
+def quick_cf_audit(path):
+    """Structural CF-1.8 audit of one file. Returns a list of
+    ``(level, message)`` with level in {"ERROR", "WARN"}; empty == clean.
+
+    Opened with ``decode_cf=False`` so on-disk dtypes/attrs (e.g. uint8
+    masks, raw ``_FillValue``/``flag_values``) are inspected as written.
+    """
+    issues = []
+    err = lambda m: issues.append(("ERROR", m))
+    warn = lambda m: issues.append(("WARN", m))
+
+    ds = xr.open_dataset(path, decode_cf=False)
+    try:
+        conv = str(ds.attrs.get("Conventions", ""))
+        if not conv.startswith("CF-1"):
+            err(f"global attr Conventions={conv!r} is not CF-1.x")
+        for a in ("title", "source", "history"):
+            if not ds.attrs.get(a):
+                warn(f"missing recommended global attr {a!r}")
+
+        # grid_mapping variable
+        gm_name = "crs"
+        if gm_name not in ds.variables:
+            err(f"no grid-mapping variable {gm_name!r}")
+        else:
+            gm = ds[gm_name]
+            if not (gm.attrs.get("grid_mapping_name") or gm.attrs.get("crs_wkt")):
+                err(f"{gm_name!r} lacks grid_mapping_name/crs_wkt")
+            # cfchecker (5.6) does NOT validate crs_wkt syntax — do it here
+            # with pyproj so we have positive proof, not an assumption.
+            wkt = gm.attrs.get("crs_wkt")
+            if wkt:
+                try:
+                    import pyproj
+                    pc = pyproj.CRS.from_wkt(wkt)
+                    epsg_attr = gm.attrs.get("epsg_code")
+                    if epsg_attr and pc.to_epsg() != int(epsg_attr):
+                        err(f"crs_wkt parses to EPSG:{pc.to_epsg()} but "
+                            f"epsg_code={epsg_attr}")
+                except Exception as e:  # noqa: BLE001
+                    err(f"crs_wkt is not valid WKT-CRS: {e}")
+
+        spatial = [v for v in ds.data_vars
+                   if {"y", "x"}.issubset(set(ds[v].dims))]
+        for v in spatial:
+            if ds[v].attrs.get("grid_mapping") != gm_name:
+                err(f"{v}: grid_mapping != {gm_name!r}")
+
+        # coordinate attrs
+        if "x" in ds.coords:
+            ax = ds["x"].attrs
+            if ax.get("standard_name") != "projection_x_coordinate":
+                err("x: standard_name != projection_x_coordinate")
+            if not ax.get("units"):
+                err("x: missing units")
+            if ax.get("axis") != "X":
+                warn("x: axis != 'X'")
+        if "y" in ds.coords:
+            ay = ds["y"].attrs
+            if ay.get("standard_name") != "projection_y_coordinate":
+                err("y: standard_name != projection_y_coordinate")
+            if not ay.get("units"):
+                err("y: missing units")
+        if "time" in ds.coords:
+            tu = ds["time"].attrs.get("units", "")
+            if "since" not in tu:
+                err(f"time: non-CF units {tu!r}")
+            if not ds["time"].attrs.get("calendar"):
+                warn("time: missing calendar")
+
+        # flag variables: flag_values dtype must match var dtype; counts align
+        for v in ds.data_vars:
+            fv = ds[v].attrs.get("flag_values")
+            fm = ds[v].attrs.get("flag_meanings")
+            if fv is None and fm is None:
+                continue
+            if fv is None or fm is None:
+                err(f"{v}: only one of flag_values/flag_meanings present")
+                continue
+            fv = np.atleast_1d(fv)
+            if fv.dtype != ds[v].dtype:
+                err(f"{v}: flag_values dtype {fv.dtype} != var dtype "
+                    f"{ds[v].dtype}")
+            if len(str(fm).split()) != fv.size:
+                err(f"{v}: {fv.size} flag_values but "
+                    f"{len(str(fm).split())} flag_meanings")
+
+        if "water_mask_ndwi" in ds.variables:
+            wm = ds["water_mask_ndwi"]
+            fillv = wm.attrs.get("_FillValue", wm.encoding.get("_FillValue"))
+            if fillv is None:
+                err("water_mask_ndwi: no _FillValue (missing-data sentinel)")
+            if str(wm.dtype) != "uint8":
+                warn(f"water_mask_ndwi dtype {wm.dtype} (expected uint8)")
+    finally:
+        ds.close()
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# Authoritative cfchecker wrapper
+# ---------------------------------------------------------------------------
+
+def _cfchecks_exe():
+    return shutil.which("cfchecks")
+
+
+def check_file(path, version="1.8"):
+    """Run the authoritative ``cfchecks`` on one file.
+
+    Returns ``{path, n_errors, n_warnings, ok, output}``. Raises
+    ``RuntimeError`` if ``cfchecker`` is not installed.
+    """
+    exe = _cfchecks_exe()
+    if exe is None:
+        raise RuntimeError(
+            "cfchecker not installed — `conda install -c conda-forge "
+            "cfchecker` (or pip install cfchecker; needs UDUNITS2)."
+        )
+    res = subprocess.run([exe, "-v", str(version), str(path)],
+                          capture_output=True, text=True)
+    out = (res.stdout or "") + (res.stderr or "")
+    me = re.search(r"ERRORS detected:\s*(\d+)", out)
+    mw = re.search(r"WARNINGS given:\s*(\d+)", out)
+    n_err = int(me.group(1)) if me else None
+    n_warn = int(mw.group(1)) if mw else None
+    ok = (n_err == 0) if n_err is not None else (res.returncode == 0)
+    return {"path": str(path), "n_errors": n_err, "n_warnings": n_warn,
+            "ok": ok, "output": out}
+
+
+def _expand(paths):
+    files = []
+    for p in paths:
+        if os.path.isdir(p):
+            files += sorted(glob.glob(os.path.join(p, "**", "*.nc"),
+                                      recursive=True))
+        else:
+            files.append(p)
+    return files
+
+
+def cf_check(paths, version="1.8", workers=8, quick=True):
+    """Validate files/dirs. Always runs the structural audit; additionally
+    runs ``cfchecker`` when available.
+
+    Returns ``(all_ok, results)`` where each result has ``path``,
+    ``quick_errors``/``quick_warnings`` and (if cfchecker ran) ``cf_errors``.
+    """
+    files = _expand(list(paths))
+    have_cfchecks = _cfchecks_exe() is not None
+    results = []
+
+    def _one(f):
+        r = {"path": f}
+        if quick:
+            qi = quick_cf_audit(f)
+            r["quick_errors"] = [m for lvl, m in qi if lvl == "ERROR"]
+            r["quick_warnings"] = [m for lvl, m in qi if lvl == "WARN"]
+        if have_cfchecks:
+            try:
+                cr = check_file(f, version=version)
+                r["cf_errors"] = cr["n_errors"]
+                r["cf_warnings"] = cr["n_warnings"]
+                r["cf_output"] = cr["output"]
+            except Exception as e:  # noqa: BLE001
+                r["cf_error_msg"] = str(e)
+        return r
+
+    with ThreadPoolExecutor(max_workers=max(1, workers)) as ex:
+        results = list(ex.map(_one, files))
+
+    all_ok = True
+    for r in results:
+        ok = not r.get("quick_errors")
+        if "cf_errors" in r and r["cf_errors"]:
+            ok = False
+        all_ok = all_ok and ok
+    return all_ok, results, have_cfchecks
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main(argv=None):
+    p = argparse.ArgumentParser(
+        description="CF-1.8 check (structural audit + cfchecker if installed)")
+    p.add_argument("paths", nargs="+", help=".nc files or directories")
+    p.add_argument("-v", "--version", default="1.8")
+    p.add_argument("--workers", type=int, default=8)
+    p.add_argument("--no-quick", action="store_true",
+                   help="skip the dependency-free structural audit")
+    a = p.parse_args(argv)
+
+    all_ok, results, have = cf_check(
+        a.paths, version=a.version, workers=a.workers, quick=not a.no_quick)
+    status = ("AVAILABLE" if have
+              else "NOT installed (structural pre-check only)")
+    print(f"standard cfchecker: {status}\n")
+    for r in sorted(results, key=lambda x: x["path"]):
+        qn = len(r.get("quick_errors", []))
+        cn = r.get("cf_errors")
+        tag = "PASS" if (qn == 0 and not cn) else "FAIL"
+        extra = f" cf_err={cn}" if cn is not None else (
+            f" ({r['cf_error_msg']})" if "cf_error_msg" in r else "")
+        print(f"[{tag}] {r['path']}  quick_err={qn} "
+              f"quick_warn={len(r.get('quick_warnings', []))}{extra}")
+        for m in r.get("quick_errors", []):
+            print(f"        ERROR {m}")
+    print(f"\n{'ALL CLEAN' if all_ok else 'FAILURES PRESENT'} "
+          f"({len(results)} file(s))")
+    sys.exit(0 if all_ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sat_tile_stack/coregister.py
+++ b/sat_tile_stack/coregister.py
@@ -1,23 +1,23 @@
 """
-Co-register external rasterized binary layers onto per-lake tile stacks.
+Co-register external data sources onto per-lake v2 tile stacks.
 
-Currently supports appending NDWI water masks from yearly zarr datacubes
-(produced upstream by the supraglacial_lake_id pipeline) onto per-lake
-tile stacks. The zarr stores live in EPSG:3413; per-lake stacks are in
-their native UTM projection (e.g. EPSG:32622 for CW Greenland tile 22W*).
+sat-tile-stack is the *only* writer of the canonical per-lake `.nc`. Every
+external source is a producer that emits its own intermediate artifact; the
+functions here ingest those artifacts and write them onto the stack as
+**new top-level CF data variables** (never as extra bands of `reflectance`).
 
-Per-lake flow:
-  1. Read the lake's UTM bbox from x/y coords.
-  2. Project the bbox into EPSG:3413 (with a small buffer) and crop the zarr.
-  3. For each lake timestep, exact-day match against the zarr time index.
-       hit  -> reproject (nearest) onto the lake's UTM grid.
-       miss -> zero-fill.
-  4. Append as a new band of the existing data variable (default
-     ``reflectance``) and extend band-indexed coords by replicating the
-     last existing band's metadata.
-  5. Write to a parallel output path (never overwrites the input).
+Three ingest paths, one per artifact shape:
 
-Designed as a per-lake function for SLURM array jobs.
+  add_raster_zarr    yearly EPSG:3413 binary zarr  -> (time, y, x) uint8
+                     e.g. Shahin NDWI daily masks  -> `water_mask_ndwi`
+  add_static_polygon GeoJSON lake polygon          -> (y, x)       uint8
+                     e.g. Dunmire 2021 footprint   -> `lake_boundary` (STATIC)
+  add_scalar_series  (ids, time) NetCDF series     -> (time,)       float32
+                     e.g. Dunmire 2025 S2_water    -> `p_water`
+
+All writes go through `io.write_netcdf` (CF-1.8 finalize + atomic temp-rename)
+so partial writes can't corrupt a good file and grid_mapping is consistent.
+Designed as per-lake functions for SLURM array jobs.
 """
 
 from __future__ import annotations
@@ -27,8 +27,10 @@ import json
 from pathlib import Path
 
 import numpy as np
+import pandas as pd
 import pyproj
 import rasterio.crs
+import rasterio.features
 import rasterio.transform
 import rasterio.warp
 import xarray as xr
@@ -36,70 +38,387 @@ from rasterio.enums import Resampling
 
 
 # ---------------------------------------------------------------------------
+# Default CF attrs for the known ESSD targets (callers may override)
+# ---------------------------------------------------------------------------
+
+NDWI_MASK_ATTRS = {
+    "long_name": "NDWI-derived supraglacial water mask (dynamic)",
+    "flag_values": np.array([0, 1], dtype=np.uint8),
+    "flag_meanings": "no_water water",
+    "source": (
+        "supraglacial_lake_id pipeline (Shahin): Sentinel-2 L2A NDWI > 0.3 "
+        "daily binary mask, ice-clipped (NSIDC-0793). Reprojected from "
+        "EPSG:3413 to the lake UTM grid by nearest-neighbour. A stack day "
+        "with no matching NDWI date is set to the _FillValue (no NDWI "
+        "observation), decoded as NaN on read - it is NOT no_water."
+    ),
+}
+
+LAKE_BOUNDARY_ATTRS = {
+    "long_name": "static lake footprint (Dunmire 2021)",
+    "flag_values": np.array([0, 1], dtype=np.uint8),
+    "flag_meanings": "outside_lake inside_lake",
+    "source": (
+        "Dunmire et al. (2021) per-lake maximum-extent polygon, rasterized "
+        "onto the lake UTM grid (all_touched). Time-invariant."
+    ),
+}
+
+P_WATER_ATTRS = {
+    "long_name": "fractional lake water extent (Dunmire 2025, S2_water)",
+    "units": "1",
+    "valid_range": np.array([0.0, 1.0], dtype="float32"),
+    "comment": (
+        "Dimensionless S2-derived water fraction in [0, 1] (NOT an area). "
+        "Aligned to stack dates by calendar day; NaN where Dunmire has no "
+        "value for that day."
+    ),
+    "source": "Dunmire et al. (2025), S2_water.",
+}
+
+NDWI_FROM_STACK_ATTRS = {
+    "long_name": "NDWI-derived supraglacial water mask",
+    "flag_values": np.array([0, 1], dtype=np.uint8),
+    "flag_meanings": "no_water water",
+    "source": (
+        "Water where NDWI = (B02 - B04)/(B02 + B04) > 0.3, computed "
+        "pixel-wise from this dataset's own Sentinel-2 L2A surface "
+        "reflectance (boa_add_offset applied per timestep). No cloud masking "
+        "and no ice-sheet clip applied - combine with the `cloud_mask` "
+        "variable downstream as needed. NDWI index and threshold after "
+        "Dunmire et al. (2021, 2025)."
+    ),
+    "references": "Dunmire et al. (2021); Dunmire et al. (2025)",
+}
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
-def add_ndwi_mask(
+def add_raster_zarr(
     input_nc,
-    zarr_path,
     output_nc,
-    var: str = "reflectance",
-    band_dim: str = "band",
-    new_band_name: str = "ndwi_mask",
-    bbox_buffer_m: float = 100.0,
+    *,
+    zarr_path,
     zarr_var: str = "ndwi_mask",
+    target_var: str = "water_mask_ndwi",
     zarr_crs: str = "EPSG:3413",
+    bbox_buffer_m: float = 100.0,
+    target_dtype="uint8",
+    target_attrs: dict | None = None,
+    nodata: int = 255,
+    nan_gate_var: str | None = None,
 ) -> dict:
-    """Append a co-registered NDWI mask band to a per-lake tile stack.
+    """Reproject a yearly EPSG:3413 binary zarr onto the lake grid as a new
+    ``(time, y, x)`` data variable. Exact-day match; a stack day with no
+    matching zarr date is filled with ``nodata`` and declared as the
+    CF ``_FillValue`` (decoded to NaN on read - missing, not no_water).
 
-    Returns a small dict of summary stats: n_time, n_days_matched,
-    n_pixels_water (across the whole cube), bbox_3413.
+    ``nan_gate_var`` (e.g. ``"p_water"``) is an existing ``(time,)`` variable
+    in *input_nc* used as a cross-product observation gate: any timestep where
+    it is NaN is also set to ``nodata`` here. Rationale: Shahin's merged-daily
+    product cannot distinguish 'this lake's tile unimaged' from a real 0
+    (fill_value 0, source_items unreadable), so an independent per-lake
+    'no usable optical observation' signal (Dunmire 2025 p_water missing) is
+    used to mark those timesteps missing rather than fabricating no_water.
+    Requires the gate variable to already be present -> run add_scalar_series
+    before add_raster_zarr.
     """
-    input_nc = Path(input_nc)
-    output_nc = Path(output_nc)
+    input_nc, output_nc = Path(input_nc), Path(output_nc)
     output_nc.parent.mkdir(parents=True, exist_ok=True)
+    if target_attrs is None:
+        target_attrs = NDWI_MASK_ATTRS if target_var == "water_mask_ndwi" else {}
 
-    ds_in = xr.open_dataset(input_nc)
+    ds_in = xr.open_dataset(input_nc).load()
     try:
-        da = ds_in[var]
-        if da.dims != ("time", band_dim, "y", "x"):
-            raise ValueError(
-                f"{input_nc.name}: expected dims (time, {band_dim}, y, x), "
-                f"got {da.dims}"
-            )
-
-        crs_in_str = (
-            ds_in.attrs.get("crs")
-            or ds_in.attrs.get("proj:code")
-            or "EPSG:32622"
-        )
-        crs_in = pyproj.CRS.from_user_input(crs_in_str)
+        crs_in = _stack_crs(ds_in)
         crs_zarr = pyproj.CRS.from_user_input(zarr_crs)
-
-        x_coords = ds_in.x.values.astype(np.float64)
-        y_coords = ds_in.y.values.astype(np.float64)
+        x = ds_in.x.values.astype(np.float64)
+        y = ds_in.y.values.astype(np.float64)
         times = ds_in.time.values
 
-        bbox_utm = _coord_bbox(x_coords, y_coords)
+        bbox_utm = _coord_bbox(x, y)
         bbox_3413 = _project_bbox(bbox_utm, crs_in, crs_zarr, bbox_buffer_m)
-
         cropped = _crop_zarr(zarr_path, zarr_var, bbox_3413)
-        ndwi_cube, n_matched = _build_ndwi_cube(
-            cropped, times, x_coords, y_coords, crs_zarr, crs_in,
+        cube, n_matched = _build_raster_cube(
+            cropped, times, x, y, crs_zarr, crs_in, nodata
         )
-        ds_out = _append_band(ds_in, var, band_dim, ndwi_cube, new_band_name)
+
+        # Cross-product observation gate: timesteps where `nan_gate_var`
+        # (e.g. p_water) is missing -> this lake had no usable optical
+        # observation that day, so the NDWI 0/1 there is not trustworthy.
+        # Set those whole frames to `nodata` while still uint8.
+        n_gated = 0
+        attrs = dict(target_attrs or {})
+        if nan_gate_var is not None:
+            if nan_gate_var not in ds_in.variables:
+                raise KeyError(
+                    f"nan_gate_var {nan_gate_var!r} not in {input_nc.name}; "
+                    f"run add_scalar_series before add_raster_zarr."
+                )
+            g = np.asarray(ds_in[nan_gate_var].values)
+            if g.shape != (cube.shape[0],):
+                raise ValueError(
+                    f"{nan_gate_var!r} must be 1-D over time "
+                    f"({cube.shape[0]},), got {g.shape}"
+                )
+            gate = ~np.isfinite(g)
+            cube[gate] = nodata
+            n_gated = int(gate.sum())
+            attrs["comment"] = (
+                (attrs.get("comment", "") + f" Timesteps where "
+                 f"'{nan_gate_var}' is missing are set to _FillValue "
+                 "(no usable optical observation of this lake; cross-product "
+                 "gate) even if the NDWI product reported detections.").strip()
+            )
+
+        ds_out = _set_data_var(
+            ds_in, cube.astype(target_dtype), ("time", "y", "x"),
+            target_var, attrs,
+        )
+        # CF missing-data: declare the no-NDWI-day sentinel as _FillValue so
+        # xarray decodes it to NaN on read (consistent with reflectance /
+        # p_water no-data). Kept in encoding, not attrs.
+        ds_out[target_var].encoding["_FillValue"] = \
+            np.dtype(target_dtype).type(nodata)
     finally:
         ds_in.close()
 
-    _write_atomic(ds_out, output_nc, var)
-
+    _write_atomic(ds_out, output_nc,
+                  f"co-registered {target_var} from raster zarr")
     return {
-        "input": str(input_nc),
-        "output": str(output_nc),
-        "n_time": int(len(times)),
+        "input": str(input_nc), "output": str(output_nc),
+        "target_var": target_var, "n_time": int(len(times)),
         "n_days_matched": int(n_matched),
-        "n_pixels_water": int(ndwi_cube.sum()),
+        "n_days_gated": int(n_gated),
+        "n_pixels_water": int((np.asarray(cube) == 1).sum()),
         "bbox_3413": tuple(float(v) for v in bbox_3413),
+    }
+
+
+def add_ndwi_mask(input_nc, zarr_path, output_nc, **kw) -> dict:
+    """Backward-compat wrapper: Shahin NDWI zarr -> ``water_mask_ndwi``."""
+    return add_raster_zarr(
+        input_nc, output_nc, zarr_path=zarr_path,
+        zarr_var=kw.pop("zarr_var", "ndwi_mask"),
+        target_var=kw.pop("target_var", "water_mask_ndwi"),
+        **kw,
+    )
+
+
+def add_ndwi_from_stack(
+    input_nc,
+    output_nc,
+    *,
+    ndwi_min: float = 0.3,
+    target_var: str = "water_mask_ndwi",
+    blue_band: str = "B02",
+    red_band: str = "B04",
+    nodata: int = 255,
+    target_attrs: dict | None = None,
+) -> dict:
+    """Derive ``water_mask_ndwi`` pixel-wise from the stack's OWN reflectance.
+
+    ``NDWI = (blue - red) / (blue + red)`` on offset-corrected L2A
+    reflectance (the /quantification scale cancels in the ratio; the
+    additive ``boa_add_offset`` does not, so it is applied per timestep).
+    Water where ``NDWI > ndwi_min``. Any non-finite pixel — no-observation
+    NaNs already in ``reflectance``, the all-band-zero nodata NaNs, or a
+    zero denominator — propagates to ``nodata`` and is declared the CF
+    ``_FillValue`` (decodes to NaN on read), strictly **per pixel**, no
+    whole-frame logic. No cloud masking, no ice clip (ship `cloud_mask`
+    alongside; the user filters cloud downstream). Replaces the external
+    NDWI-zarr path; ``add_raster_zarr`` is kept for generic rasters but is
+    not used for NDWI.
+    """
+    input_nc, output_nc = Path(input_nc), Path(output_nc)
+    output_nc.parent.mkdir(parents=True, exist_ok=True)
+    if target_attrs is None:
+        target_attrs = (NDWI_FROM_STACK_ATTRS
+                        if target_var == "water_mask_ndwi" else {})
+
+    ds_in = xr.open_dataset(input_nc).load()
+    try:
+        refl = ds_in["reflectance"]
+        # band is now a numeric CF index; short names live in `band_name`
+        # (fall back to the band coord for legacy string-band files).
+        # band_name may round-trip as a data var rather than a coord, so
+        # look in .variables (covers both); fall back to legacy string band.
+        if "band_name" in ds_in.variables:
+            names = [str(b) for b in ds_in["band_name"].values]
+        else:
+            names = [str(b) for b in refl["band"].values]
+        for bn in (blue_band, red_band):
+            if bn not in names:
+                raise KeyError(f"{bn!r} not in reflectance bands {names}")
+        bi, ri = names.index(blue_band), names.index(red_band)
+
+        blue = refl.isel(band=bi).values.astype("float64")
+        red = refl.isel(band=ri).values.astype("float64")
+
+        if "boa_add_offset" in ds_in.variables:
+            off = np.asarray(ds_in["boa_add_offset"].values,
+                             dtype="float64").reshape(-1, 1, 1)
+        else:
+            off = 0.0
+        blue = blue + off          # NaN offset (no-obs day) -> NaN, picked up
+        red = red + off
+
+        with np.errstate(invalid="ignore", divide="ignore"):
+            ndwi = (blue - red) / (blue + red)
+
+        cube = np.full(ndwi.shape, nodata, dtype=np.uint8)
+        valid = np.isfinite(ndwi)
+        cube[valid] = (ndwi[valid] > ndwi_min).astype(np.uint8)
+
+        ds_out = _set_data_var(
+            ds_in, cube, ("time", "y", "x"), target_var, target_attrs
+        )
+        ds_out[target_var].encoding["_FillValue"] = np.uint8(nodata)
+        n_water = int((cube == 1).sum())
+        n_missing = int((cube == nodata).sum())
+    finally:
+        ds_in.close()
+
+    _write_atomic(ds_out, output_nc,
+                  f"derived {target_var} = NDWI>{ndwi_min} from stack bands")
+    return {
+        "input": str(input_nc), "output": str(output_nc),
+        "target_var": target_var, "ndwi_min": float(ndwi_min),
+        "n_pixels_water": n_water, "n_pixels_missing": n_missing,
+        "n_pixels_total": int(cube.size),
+    }
+
+
+def add_static_polygon(
+    input_nc,
+    output_nc,
+    *,
+    geojson,
+    lake_id: str,
+    target_var: str = "lake_boundary",
+    id_field: str = "new_id",
+    geojson_crs: str = "EPSG:4326",
+    all_touched: bool = True,
+    target_attrs: dict | None = None,
+) -> dict:
+    """Rasterize one lake's polygon from a GeoJSON onto the lake grid as a
+    **static** ``(y, x)`` uint8 data variable (no time dimension).
+    """
+    input_nc, output_nc = Path(input_nc), Path(output_nc)
+    output_nc.parent.mkdir(parents=True, exist_ok=True)
+    if target_attrs is None:
+        target_attrs = (LAKE_BOUNDARY_ATTRS
+                        if target_var == "lake_boundary" else {})
+
+    from shapely.geometry import shape
+    from shapely.ops import transform as shp_transform
+
+    feats = json.load(open(geojson))["features"]
+    match = [f for f in feats if str(f["properties"].get(id_field)) == str(lake_id)]
+    if not match:
+        raise KeyError(
+            f"{lake_id!r} not found in {Path(geojson).name} "
+            f"(field {id_field!r})"
+        )
+    geom = shape(match[0]["geometry"])
+
+    ds_in = xr.open_dataset(input_nc).load()
+    try:
+        crs_in = _stack_crs(ds_in)
+        x = ds_in.x.values.astype(np.float64)
+        y = ds_in.y.values.astype(np.float64)
+
+        tx = pyproj.Transformer.from_crs(
+            pyproj.CRS.from_user_input(geojson_crs), crs_in, always_xy=True
+        )
+        geom_utm = shp_transform(lambda a, b: tx.transform(a, b), geom)
+
+        dx = float(abs(x[1] - x[0]))
+        dy = float(abs(y[1] - y[0]))
+        north = float(y.max()) + dy / 2.0
+        west = float(x.min()) - dx / 2.0
+        transform = rasterio.transform.from_origin(west, north, dx, dy)
+
+        mask = rasterio.features.rasterize(
+            [(geom_utm, 1)],
+            out_shape=(len(y), len(x)),
+            transform=transform,
+            fill=0,
+            dtype="uint8",
+            all_touched=all_touched,
+        )
+        # rasterize is north-up (row 0 = max y). Match the stack's y order.
+        if y[0] < y[-1]:                       # ascending y -> flip rows
+            mask = mask[::-1, :]
+
+        ds_out = _set_data_var(
+            ds_in, mask, ("y", "x"), target_var, target_attrs
+        )
+    finally:
+        ds_in.close()
+
+    _write_atomic(ds_out, output_nc,
+                  f"co-registered static {target_var} from polygon")
+    return {
+        "input": str(input_nc), "output": str(output_nc),
+        "target_var": target_var, "lake_id": str(lake_id),
+        "n_pixels_inside": int(mask.sum()),
+    }
+
+
+def add_scalar_series(
+    input_nc,
+    output_nc,
+    *,
+    source_nc,
+    source_var: str,
+    lake_id: str,
+    target_var: str = "p_water",
+    ids_dim: str = "ids",
+    time_dim: str = "time",
+    target_attrs: dict | None = None,
+) -> dict:
+    """Join a ``(ids, time)`` NetCDF series (e.g. Dunmire S2_water) onto the
+    lake stack as a ``(time,)`` float32 variable, aligned by calendar day.
+    """
+    input_nc, output_nc = Path(input_nc), Path(output_nc)
+    output_nc.parent.mkdir(parents=True, exist_ok=True)
+    if target_attrs is None:
+        target_attrs = P_WATER_ATTRS if target_var == "p_water" else {}
+
+    ds_in = xr.open_dataset(input_nc).load()
+    src = xr.open_dataset(source_nc)
+    try:
+        ids = src[ids_dim].values.astype(str)
+        if str(lake_id) not in set(ids):
+            raise KeyError(
+                f"{lake_id!r} not in {Path(source_nc).name} {ids_dim!r} "
+                f"(n={ids.size})"
+            )
+        series = src[source_var].sel({ids_dim: str(lake_id)})
+
+        src_idx = pd.to_datetime(src[time_dim].values).normalize()
+        tgt_idx = pd.to_datetime(ds_in.time.values).normalize()
+        s = pd.Series(np.asarray(series.values, dtype="float64"), index=src_idx)
+        s = s[~s.index.duplicated(keep="first")]
+        vals = s.reindex(tgt_idx).to_numpy().astype("float32")
+        n_match = int(np.isfinite(vals).sum())
+
+        ds_out = _set_data_var(
+            ds_in, vals, ("time",), target_var, target_attrs
+        )
+    finally:
+        ds_in.close()
+        src.close()
+
+    _write_atomic(ds_out, output_nc,
+                  f"co-registered {target_var} from scalar series")
+    return {
+        "input": str(input_nc), "output": str(output_nc),
+        "target_var": target_var, "lake_id": str(lake_id),
+        "n_time": int(len(vals)), "n_days_matched": n_match,
     }
 
 
@@ -107,301 +426,225 @@ def add_ndwi_mask(
 # Internals
 # ---------------------------------------------------------------------------
 
-def _coord_bbox(x: np.ndarray, y: np.ndarray) -> tuple:
-    """Pixel-edge inclusive bbox (x_min, y_min, x_max, y_max) from coord arrays.
+def _stack_crs(ds):
+    """Resolve the per-lake stack CRS from attrs, with a CW-Greenland default."""
+    hint = (ds.attrs.get("crs") or ds.attrs.get("proj:code")
+            or (f"EPSG:{int(ds['epsg'].item())}"
+                if "epsg" in ds.variables else None)
+            or "EPSG:32622")
+    return pyproj.CRS.from_user_input(hint)
 
-    Coords are assumed to be pixel centers on a regular grid.
-    """
-    pix_x = float(abs(x[1] - x[0]))
-    pix_y = float(abs(y[1] - y[0]))
-    return (
-        float(x.min()) - pix_x / 2,
-        float(y.min()) - pix_y / 2,
-        float(x.max()) + pix_x / 2,
-        float(y.max()) + pix_y / 2,
-    )
+
+def _coord_bbox(x: np.ndarray, y: np.ndarray) -> tuple:
+    """Pixel-edge-inclusive (x_min,y_min,x_max,y_max) from pixel-center coords."""
+    px = float(abs(x[1] - x[0]))
+    py = float(abs(y[1] - y[0]))
+    return (float(x.min()) - px / 2, float(y.min()) - py / 2,
+            float(x.max()) + px / 2, float(y.max()) + py / 2)
 
 
 def _project_bbox(bbox, src_crs, dst_crs, buffer):
-    """Project a bbox between CRSs, sampling all 4 corners and buffering."""
+    """Project a bbox between CRSs, sampling all 4 corners, then buffer."""
     x_min, y_min, x_max, y_max = bbox
     tx = pyproj.Transformer.from_crs(src_crs, dst_crs, always_xy=True)
-    cx, cy = tx.transform(
-        [x_min, x_max, x_min, x_max],
-        [y_min, y_min, y_max, y_max],
-    )
-    return (
-        float(min(cx)) - buffer,
-        float(min(cy)) - buffer,
-        float(max(cx)) + buffer,
-        float(max(cy)) + buffer,
-    )
+    cx, cy = tx.transform([x_min, x_max, x_min, x_max],
+                          [y_min, y_min, y_max, y_max])
+    return (float(min(cx)) - buffer, float(min(cy)) - buffer,
+            float(max(cx)) + buffer, float(max(cy)) + buffer)
+
+
+def _decode_zarr_time(raw, attrs):
+    """Decode a CF-style time array (X since ref) to datetime64[ns]."""
+    units = attrs.get("units", "")
+    if "since" not in units:
+        return raw.astype("datetime64[ns]")
+    step, _, ref = units.partition(" since ")
+    ref_dt = np.datetime64(ref.strip().replace(" ", "T"))
+    np_unit = {"days": "D", "day": "D", "hours": "h", "hour": "h",
+               "minutes": "m", "minute": "m", "seconds": "s",
+               "second": "s"}.get(step.strip().lower(), "D")
+    return (ref_dt + raw.astype(np.int64).astype(
+        f"timedelta64[{np_unit}]")).astype("datetime64[ns]")
 
 
 def _crop_zarr(zarr_path, var, bbox):
-    """Load a tiny in-memory crop of the zarr to the given EPSG:3413 bbox.
-
-    Reads the needed arrays (``var``, ``x``, ``y``, ``time``) directly via
-    the low-level zarr API and constructs an xarray DataArray. Bypasses
-    xarray's zarr engine, which eagerly enumerates the whole group and
-    chokes on the ``source_items`` array's fill_value in the upstream
-    NDWI stores.
+    """Tiny in-memory crop of the zarr to an EPSG:3413 bbox via low-level API
+    (bypasses xarray's eager group enumeration on the upstream NDWI stores).
     """
     import zarr
 
     zarr_path = str(zarr_path)
     var_arr = zarr.open_array(f"{zarr_path}/{var}", mode="r")
-    x_arr   = zarr.open_array(f"{zarr_path}/x",   mode="r")
-    y_arr   = zarr.open_array(f"{zarr_path}/y",   mode="r")
-    t_arr   = zarr.open_array(f"{zarr_path}/time", mode="r")
-
-    x_full = np.asarray(x_arr[:], dtype=np.float64)
-    y_full = np.asarray(y_arr[:], dtype=np.float64)
-    times  = _decode_zarr_time(np.asarray(t_arr[:]), dict(t_arr.attrs))
+    x_full = np.asarray(zarr.open_array(f"{zarr_path}/x", mode="r")[:], np.float64)
+    y_full = np.asarray(zarr.open_array(f"{zarr_path}/y", mode="r")[:], np.float64)
+    t_arr = zarr.open_array(f"{zarr_path}/time", mode="r")
+    times = _decode_zarr_time(np.asarray(t_arr[:]), dict(t_arr.attrs))
 
     x_min, y_min, x_max, y_max = bbox
-    x_mask = (x_full >= x_min) & (x_full <= x_max)
-    y_mask = (y_full >= y_min) & (y_full <= y_max)
-    x_idx = np.where(x_mask)[0]
-    y_idx = np.where(y_mask)[0]
-
-    if x_idx.size == 0 or y_idx.size == 0:
+    xi = np.where((x_full >= x_min) & (x_full <= x_max))[0]
+    yi = np.where((y_full >= y_min) & (y_full <= y_max))[0]
+    if xi.size == 0 or yi.size == 0:
         return xr.DataArray(
-            np.zeros((len(times), 0, 0), dtype=np.int8),
+            np.zeros((len(times), 0, 0), np.int8),
             dims=("time", "y", "x"),
             coords={"time": times, "y": np.array([]), "x": np.array([])},
         )
-
-    x_lo, x_hi = int(x_idx.min()), int(x_idx.max()) + 1
-    y_lo, y_hi = int(y_idx.min()), int(y_idx.max()) + 1
+    x_lo, x_hi = int(xi.min()), int(xi.max()) + 1
+    y_lo, y_hi = int(yi.min()), int(yi.max()) + 1
     data = np.asarray(var_arr[:, y_lo:y_hi, x_lo:x_hi])
     return xr.DataArray(
-        data,
-        dims=("time", "y", "x"),
-        coords={
-            "time": times,
-            "y": y_full[y_lo:y_hi],
-            "x": x_full[x_lo:x_hi],
-        },
+        data, dims=("time", "y", "x"),
+        coords={"time": times, "y": y_full[y_lo:y_hi], "x": x_full[x_lo:x_hi]},
     )
 
 
-def _decode_zarr_time(raw, attrs):
-    """Decode a CF-style time array (days/seconds since X) to datetime64[ns]."""
-    units = attrs.get("units", "")
-    if "since" not in units:
-        return raw.astype("datetime64[ns]")
-    step, _, ref = units.partition(" since ")
-    step = step.strip().lower()
-    ref_dt = np.datetime64(ref.strip().replace(" ", "T"))
-    unit_map = {
-        "days": "D", "day": "D",
-        "hours": "h", "hour": "h",
-        "minutes": "m", "minute": "m",
-        "seconds": "s", "second": "s",
-    }
-    np_unit = unit_map.get(step, "D")
-    return (ref_dt + raw.astype(np.int64).astype(f"timedelta64[{np_unit}]")).astype("datetime64[ns]")
-
-
-def _build_ndwi_cube(cropped, times, dst_x, dst_y, src_crs, dst_crs):
-    """Build a (time, n_y, n_x) uint8 cube on the lake's UTM grid.
-
-    Reprojects only the days where the lake date matches a zarr date
-    exactly; everything else is zero.
+def _build_raster_cube(cropped, times, dst_x, dst_y, src_crs, dst_crs,
+                       nodata):
+    """(time, ny, nx) cube on the lake UTM grid; only exact-day matches are
+    reprojected (nearest). Days with no matching zarr date stay ``nodata``
+    (the CF _FillValue), i.e. missing — distinct from a real 0 (no_water).
     """
-    n_time = len(times)
-    n_y = len(dst_y)
-    n_x = len(dst_x)
-    cube = np.zeros((n_time, n_y, n_x), dtype=np.uint8)
-
+    n_y, n_x = len(dst_y), len(dst_x)
+    cube = np.full((len(times), n_y, n_x), nodata, dtype=np.uint8)
     if cropped.size == 0 or len(cropped.x) < 2 or len(cropped.y) < 2:
         return cube, 0
 
-    z_x = cropped.x.values.astype(np.float64)
-    z_y = cropped.y.values.astype(np.float64)
-    z_pix_x = float(abs(z_x[1] - z_x[0]))
-    z_pix_y = float(abs(z_y[1] - z_y[0]))
-    src_transform = rasterio.transform.from_origin(
-        z_x.min() - z_pix_x / 2,
-        z_y.max() + z_pix_y / 2,
-        z_pix_x, z_pix_y,
-    )
+    zx = cropped.x.values.astype(np.float64)
+    zy = cropped.y.values.astype(np.float64)
+    zpx, zpy = float(abs(zx[1] - zx[0])), float(abs(zy[1] - zy[0]))
+    src_t = rasterio.transform.from_origin(
+        zx.min() - zpx / 2, zy.max() + zpy / 2, zpx, zpy)
 
-    dst_pix_x = float(abs(dst_x[1] - dst_x[0]))
-    dst_pix_y = float(abs(dst_y[1] - dst_y[0]))
-    dst_transform = rasterio.transform.from_origin(
-        float(dst_x.min()) - dst_pix_x / 2,
-        float(dst_y.max()) + dst_pix_y / 2,
-        dst_pix_x, dst_pix_y,
-    )
+    dpx, dpy = float(abs(dst_x[1] - dst_x[0])), float(abs(dst_y[1] - dst_y[0]))
+    dst_t = rasterio.transform.from_origin(
+        float(dst_x.min()) - dpx / 2, float(dst_y.max()) + dpy / 2, dpx, dpy)
 
     src_rio = rasterio.crs.CRS.from_wkt(src_crs.to_wkt())
     dst_rio = rasterio.crs.CRS.from_wkt(dst_crs.to_wkt())
 
-    z_days = cropped.time.values.astype("datetime64[D]")
-    day_to_zidx = {np.datetime64(d): i for i, d in enumerate(z_days)}
-
+    day_to_zidx = {np.datetime64(d): i for i, d in
+                   enumerate(cropped.time.values.astype("datetime64[D]"))}
     n_matched = 0
-    for t_idx, t in enumerate(times):
-        day = np.datetime64(np.datetime64(t, "D"))
-        zidx = day_to_zidx.get(day)
+    for ti, t in enumerate(times):
+        zidx = day_to_zidx.get(np.datetime64(np.datetime64(t, "D")))
         if zidx is None:
             continue
-        src = np.ascontiguousarray(cropped.isel(time=zidx).values.astype(np.uint8))
-        dst = np.zeros((n_y, n_x), dtype=np.uint8)
+        src = np.ascontiguousarray(
+            cropped.isel(time=zidx).values.astype(np.uint8))
+        dst = np.zeros((n_y, n_x), np.uint8)
         rasterio.warp.reproject(
-            source=src,
-            destination=dst,
-            src_transform=src_transform,
-            src_crs=src_rio,
-            dst_transform=dst_transform,
-            dst_crs=dst_rio,
+            source=src, destination=dst,
+            src_transform=src_t, src_crs=src_rio,
+            dst_transform=dst_t, dst_crs=dst_rio,
             resampling=Resampling.nearest,
         )
-        cube[t_idx] = dst
+        cube[ti] = dst
         n_matched += 1
     return cube, n_matched
 
 
-def _append_band(ds_in, var, band_dim, ndwi_cube, new_band_name):
-    """Return a new dataset with `ndwi_cube` appended as a new band of `var`.
-
-    Extends every 1-D band-indexed coord by replicating the last band's
-    value, so the new NDWI band's metadata mirrors the existing 'mask'
-    band's metadata (which is itself a placeholder for non-spectral bands).
-    Updates the dataset-level ``band`` attr if present.
-
-    Implementation: builds the extended array at the numpy level and
-    constructs a fresh DataArray. Avoids xarray.concat's alignment pass,
-    which gets confused by the rich set of band-indexed sub-coords on
-    sat-tile-stack outputs.
+def _set_data_var(ds_in, data, dims, target_var, target_attrs):
+    """Return ds_in + a new top-level data variable, preserving everything
+    else. Refuses to clobber `reflectance`/`cloud_mask`.
     """
-    da = ds_in[var]
-    n_bands = da.sizes[band_dim]
-    band_axis = da.dims.index(band_dim)
-
-    # Stack along band axis (numpy-level — no alignment magic).
-    new_band = ndwi_cube.astype(da.dtype)
-    new_band = np.expand_dims(new_band, axis=band_axis)
-    extended = np.concatenate([da.values, new_band], axis=band_axis)
-
-    # Build extended coord values: every coord with dims == (band,) gets one
-    # extra entry. For string/object coords (`common_name`, `title`, ...) we
-    # use ``new_band_name`` so the new band is identifiable rather than a
-    # duplicate of the existing 'mask' band's name. For numeric coords
-    # (`gsd`, `center_wavelength`, `full_width_half_max`) we replicate the
-    # last band's value — already NaN for the 'mask' band, which is the
-    # right placeholder for a non-spectral derived layer.
-    # Coords are wrapped as (dims, values) tuples so xarray binds them to
-    # the right dim instead of inferring a new same-named dim.
-    new_coords = {}
-    for cname, c in da.coords.items():
-        if c.dims == (band_dim,):
-            if cname == band_dim:
-                next_idx = int(np.asarray(c.values).max()) + 1
-                new_coords[cname] = ((band_dim,), np.append(c.values, next_idx))
-            elif np.issubdtype(c.dtype, np.character) or c.dtype == object:
-                new_coords[cname] = ((band_dim,), np.append(c.values, new_band_name))
-            else:
-                last_val = c.isel({band_dim: -1}).values
-                new_coords[cname] = ((band_dim,), np.append(c.values, last_val))
-        elif band_dim not in c.dims:
-            new_coords[cname] = c
-
-    new_da = xr.DataArray(
-        extended,
-        dims=da.dims,
-        coords=new_coords,
-        attrs=dict(da.attrs),
-        name=da.name,
-    )
-
-    # Rebuild the dataset, preserving everything else (water_area,
-    # cloudy_seq_*, time-indexed coords, attrs).
-    other_vars = {k: v for k, v in ds_in.data_vars.items() if k != var}
-    ds_out = xr.Dataset(
-        data_vars={var: new_da, **other_vars},
-        coords={k: v for k, v in ds_in.coords.items() if band_dim not in v.dims},
-        attrs=dict(ds_in.attrs),
-    )
-
-    band_names = _read_band_names_attr(ds_in.attrs)
-    if band_names is not None and len(band_names) == n_bands:
-        ds_out.attrs["band"] = band_names + [new_band_name]
-
-    ds_out.attrs.setdefault(
-        "ndwi_mask_source",
-        "NDWI > 0.3, Sentinel-2 L2A, cloud-filtered 10%, ice-clipped "
-        "(NSIDC-0793). Co-registered from EPSG:3413 zarr to lake's UTM "
-        "grid by nearest-neighbor reproject; missing days zero-filled.",
-    )
+    if target_var in ("reflectance", "cloud_mask"):
+        raise ValueError(f"refusing to overwrite core variable {target_var!r}")
+    coords = {d: ds_in[d] for d in dims}
+    da = xr.DataArray(np.asarray(data), dims=dims, coords=coords,
+                      name=target_var, attrs=dict(target_attrs or {}))
+    ds_out = ds_in.copy()
+    ds_out[target_var] = da
     return ds_out
 
 
-def _read_band_names_attr(attrs):
-    """Return the dataset-level band-name list as a Python list, or None."""
-    raw = attrs.get("band")
-    if raw is None:
-        return None
-    if isinstance(raw, (list, tuple)):
-        return [str(x) for x in raw]
-    if isinstance(raw, str):
-        try:
-            parsed = json.loads(raw)
-            if isinstance(parsed, list):
-                return [str(x) for x in parsed]
-        except Exception:
-            pass
-    return None
-
-
-def _write_atomic(ds, output_nc: Path, var: str):
-    """Write to a temp sibling and rename, so partial writes never replace good outputs.
-
-    Routes through :func:`sat_tile_stack.io.write_netcdf` so the output is
-    CF-1.8 compliant — Conventions / grid_mapping / per-variable units &
-    long_names are added in one place rather than re-implemented here.
+def _write_atomic(ds, output_nc: Path, history_action: str):
+    """Write via io.write_netcdf to a temp sibling, then atomic rename.
+    finalize_cf auto-detects spatial vars (everything with y & x dims) so
+    grid_mapping is attached consistently; (time,)-only vars are left alone.
     """
     from .io import write_netcdf
 
     tmp = output_nc.with_suffix(output_nc.suffix + ".tmp")
-    write_netcdf(
-        ds, tmp,
-        spatial_vars=(var,),
-        history_action="appended ndwi_mask band via coregister.add_ndwi_mask",
-    )
-    tmp.replace(output_nc)
+    write_netcdf(ds, tmp, history_action=history_action)
+    Path(tmp).replace(output_nc)
 
 
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
-def main():
-    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
-    p.add_argument("--input", required=True, help="Per-lake input .nc")
-    p.add_argument("--zarr", required=True, help="Year-matching NDWI zarr")
-    p.add_argument("--output", required=True, help="Output .nc path")
-    p.add_argument("--var", default="reflectance",
-                   help="Data variable to extend (default: reflectance)")
-    p.add_argument("--band_dim", default="band",
-                   help="Band dimension name (default: band)")
-    p.add_argument("--new_band_name", default="ndwi_mask",
-                   help="Name to use for the new band (default: ndwi_mask)")
-    p.add_argument("--bbox_buffer_m", type=float, default=100.0,
-                   help="Buffer (m) added when projecting bbox to EPSG:3413")
-    args = p.parse_args()
+def _main_zarr(argv=None):
+    p = argparse.ArgumentParser(description="co-register a raster zarr")
+    p.add_argument("--input", required=True)
+    p.add_argument("--output", required=True)
+    p.add_argument("--zarr", required=True)
+    p.add_argument("--zarr-var", default="ndwi_mask")
+    p.add_argument("--target-var", default="water_mask_ndwi")
+    p.add_argument("--bbox-buffer-m", type=float, default=100.0)
+    p.add_argument("--nan-gate-var", default=None,
+                   help="(time,) var already in --input; its NaN timesteps "
+                        "are set missing (e.g. p_water)")
+    a = p.parse_args(argv)
+    print(json.dumps(add_raster_zarr(
+        a.input, a.output, zarr_path=a.zarr, zarr_var=a.zarr_var,
+        target_var=a.target_var, bbox_buffer_m=a.bbox_buffer_m,
+        nan_gate_var=a.nan_gate_var), indent=2))
 
-    summary = add_ndwi_mask(
-        args.input, args.zarr, args.output,
-        var=args.var,
-        band_dim=args.band_dim,
-        new_band_name=args.new_band_name,
-        bbox_buffer_m=args.bbox_buffer_m,
-    )
-    print(json.dumps(summary, indent=2))
+
+def _main_ndwi(argv=None):
+    p = argparse.ArgumentParser(
+        description="derive water_mask_ndwi from the stack's own bands")
+    p.add_argument("--input", required=True)
+    p.add_argument("--output", required=True)
+    p.add_argument("--ndwi-min", type=float, default=0.3)
+    p.add_argument("--target-var", default="water_mask_ndwi")
+    a = p.parse_args(argv)
+    print(json.dumps(add_ndwi_from_stack(
+        a.input, a.output, ndwi_min=a.ndwi_min,
+        target_var=a.target_var), indent=2))
+
+
+def _main_polygon(argv=None):
+    p = argparse.ArgumentParser(description="co-register a static polygon")
+    p.add_argument("--input", required=True)
+    p.add_argument("--output", required=True)
+    p.add_argument("--geojson", required=True)
+    p.add_argument("--lake-id", required=True)
+    p.add_argument("--target-var", default="lake_boundary")
+    p.add_argument("--id-field", default="new_id")
+    a = p.parse_args(argv)
+    print(json.dumps(add_static_polygon(
+        a.input, a.output, geojson=a.geojson, lake_id=a.lake_id,
+        target_var=a.target_var, id_field=a.id_field), indent=2))
+
+
+def _main_scalar(argv=None):
+    p = argparse.ArgumentParser(description="co-register a scalar series")
+    p.add_argument("--input", required=True)
+    p.add_argument("--output", required=True)
+    p.add_argument("--source", required=True)
+    p.add_argument("--source-var", required=True)
+    p.add_argument("--lake-id", required=True)
+    p.add_argument("--target-var", default="p_water")
+    a = p.parse_args(argv)
+    print(json.dumps(add_scalar_series(
+        a.input, a.output, source_nc=a.source, source_var=a.source_var,
+        lake_id=a.lake_id, target_var=a.target_var), indent=2))
 
 
 if __name__ == "__main__":
-    main()
+    import sys
+
+    sub = sys.argv[1] if len(sys.argv) > 1 else ""
+    rest = sys.argv[2:]
+    if sub == "zarr":
+        _main_zarr(rest)
+    elif sub == "ndwi":
+        _main_ndwi(rest)
+    elif sub == "polygon":
+        _main_polygon(rest)
+    elif sub == "scalar":
+        _main_scalar(rest)
+    else:
+        print("usage: python -m sat_tile_stack.coregister "
+              "{zarr|ndwi|polygon|scalar} --help")

--- a/sat_tile_stack/index.html
+++ b/sat_tile_stack/index.html
@@ -251,11 +251,11 @@
 
         <h3 style="color:#4488cc; margin:12px 0 6px;">HF — Hydrofracture</h3>
         <ul style="padding-left:20px; margin:4px 0;">
-            <li>Rapid drainage (often ~1 day) where water drains <strong>within the lake extent</strong></li>
-            <li>Look for: fracture scarps, ice chunks, sudden area decrease</li>
-            <li>If a lake drains into a moulin AND also hydrofractures → label as HF</li>
-            <li>New moulins that form from hydrofracture → still HF</li>
-            <li>If truly unclear moulin vs HF → label as HF and flag for revisit</li>
+            <li>Rapid drainage (typically <strong>&lt;4 days</strong>) with water leaving <strong>mostly within the lake extent</strong> — not via a long outlet stream</li>
+            <li>Supporting cues: fracture scarps, ice chunks, sudden area decrease. <strong>A visible scarp is not required.</strong></li>
+            <li><strong>Default to HF</strong> when drainage is rapid and mostly in-basin, even without a clean scarp: you cannot demonstrate it was <em>not</em> a hydrofracture, and the imagery already shows evidence of a rapid englacial event</li>
+            <li>A moulin observed in or near the basin during/after rapid in-basin drainage may have been <em>spawned by</em> the HF event (HF events often open new moulins). Visible moulin + rapid in-basin drainage → HF, not MD</li>
+            <li>If truly unclear HF vs MD → label as HF and flag for revisit</li>
         </ul>
 
         <h3 style="color:#4488cc; margin:12px 0 6px;">MD — Moulin Drainage</h3>

--- a/sat_tile_stack/io.py
+++ b/sat_tile_stack/io.py
@@ -7,8 +7,43 @@ sanitization, and GeoTIFF export.
 
 import xarray as xr
 import numpy as np
-import json, re, warnings
+import json, re, warnings, numbers
 from datetime import datetime, timezone
+
+
+def _nc_safe_value(v):
+    """Coerce one attribute value to a netCDF-legal type.
+
+    netCDF attrs allow only str/bytes/number/array — NOT Python ``bool``
+    (``b1``). Order matters: ``bool`` is a subclass of ``int`` and
+    ``np.bool_`` is an ``np.generic``, so booleans must be caught before the
+    number/array check. Sets (e.g. stackstac's ``proj:bbox``) -> sorted list;
+    anything else non-serializable (RasterSpec, Affine) -> ``str``.
+    """
+    if isinstance(v, (bool, np.bool_)):
+        return np.int8(1 if v else 0)
+    if isinstance(v, set):
+        return sorted(v)
+    if isinstance(v, (str, bytes, list, tuple, np.ndarray, np.generic,
+                      numbers.Number)):
+        return v
+    return str(v)
+
+
+def _scrub_var_attrs(ds, drop):
+    """Drop `drop` keys and coerce values to netCDF-legal types on the global
+    attrs AND every variable's attrs (stackstac leaves a RasterSpec under
+    'spec' / an Affine under 'transform'; our checkpoint stores a bool).
+    Array/number attrs such as `flag_values` pass through untouched.
+    """
+    containers = [ds.attrs] + [ds[v].attrs for v in ds.variables]
+    for attrs in containers:
+        for k in list(attrs):
+            if k in drop:
+                attrs.pop(k)
+            else:
+                attrs[k] = _nc_safe_value(attrs[k])
+    return ds
 
 
 # ===========================================================================
@@ -35,10 +70,23 @@ def scrub_attrs(xr_obj, drop=()):
 
 _illegal_nc_name = re.compile(r"[^0-9A-Za-z_]")
 
+def _is_stringlike(arr):
+    """True if an object-dtype array actually holds strings/bytes (NetCDF can
+    write these fine as char/S1 — they must NOT be relocated to attrs)."""
+    flat = np.asarray(arr).ravel()
+    if flat.size == 0:
+        return False
+    return all(isinstance(e, (str, bytes)) for e in flat[:64] if e is not None)
+
+
 def sanitise_dataset(ds):
     """
-    Move variables with illegal NetCDF names or object dtype to global attributes.
-    Never touches dimension coordinates (band, time, x, y).
+    Move variables with illegal NetCDF names or non-serializable object dtype
+    to global attributes. Never touches dimension coordinates, and — crucially
+    — never relocates object arrays that are actually strings (e.g. band_name,
+    common_name, processing_baseline reopened as object dtype): NetCDF writes
+    those as char/S1 arrays, so dropping them silently destroys real
+    coordinates across the multi-write coregister flow.
     """
     ds = ds.copy()
     dim_coords = set(ds.dims)
@@ -46,7 +94,7 @@ def sanitise_dataset(ds):
         if v in dim_coords:
             continue
         bad_name = (":" in v) or _illegal_nc_name.search(v)
-        bad_type = ds[v].dtype == object
+        bad_type = (ds[v].dtype == object) and not _is_stringlike(ds[v].values)
         if not (bad_name or bad_type):
             continue
 
@@ -94,48 +142,50 @@ def _add_cf_metadata(ds, da):
     return finalize_cf(ds, spatial_vars=("reflectance",))
 
 
-# Known variables we annotate when present. Keys map var-name -> attrs dict.
+# Known variables/coords we annotate when present (CF safety net; values are
+# only set when missing — stack.py / coregister.py own the authoritative attrs).
+# ESSD v2 schema: reflectance + cloud_mask + water_mask_ndwi + lake_boundary
+# + p_water. No cloudy_seq_* (deferred to the JSTARS follow-up), no
+# pct*_inmask (derivable downstream).
 _KNOWN_VAR_ATTRS = {
     "reflectance": {
-        "long_name": "Sentinel-2 reflectance and derived per-pixel layers",
+        "long_name": "Sentinel-2 L2A raw surface-reflectance digital numbers",
         "units": "1",
     },
-    "water_area": {
-        "long_name": "lake water area",
-        "units": "m2",
+    "cloud_mask": {
+        "long_name": "Sentinel-2 SCL-derived cloud flag",
+        "flag_values": np.array([0, 1], dtype=np.uint8),
+        "flag_meanings": "clear cloudy",
     },
-    "cloudy_seq_rgb": {
-        "long_name": "tile usefulness prediction (RGB CNN)",
-        "units": "1",
-        "flag_values": np.array([0, 1], dtype=np.int8),
-        "flag_meanings": "cloudy useful",
+    "water_mask_ndwi": {
+        "long_name": "NDWI-derived supraglacial water mask (dynamic)",
+        "flag_values": np.array([0, 1], dtype=np.uint8),
+        "flag_meanings": "no_water water",
     },
-    "cloudy_seq_rgbn": {
-        "long_name": "tile usefulness prediction (RGB+NIR CNN)",
-        "units": "1",
-        "flag_values": np.array([0, 1], dtype=np.int8),
-        "flag_meanings": "cloudy useful",
+    "lake_boundary": {
+        "long_name": "static lake footprint (Dunmire 2021)",
+        "flag_values": np.array([0, 1], dtype=np.uint8),
+        "flag_meanings": "outside_lake inside_lake",
     },
-    "cloudy_seq_bns16": {
-        "long_name": "tile usefulness prediction (Blue+NIR+SWIR16 CNN)",
+    "p_water": {
+        "long_name": "fractional lake water extent (Dunmire 2025, S2_water)",
         "units": "1",
-        "flag_values": np.array([0, 1], dtype=np.int8),
-        "flag_meanings": "cloudy useful",
     },
     "eo_cloud_cover": {
         "long_name": "EO cloud-cover percentage from STAC item",
         "units": "percent",
     },
     "pct_nans": {
-        "long_name": "percentage of NaN pixels in the full tile",
+        "long_name": "percentage of NaN pixels in the spectral tile",
         "units": "percent",
     },
-    "pctnanpix_inmask": {
-        "long_name": "percentage of NaN pixels inside the lake mask",
-        "units": "1",
+    "processing_baseline": {
+        "long_name": "Sentinel-2 processing baseline (ESA software version)",
     },
-    "pctcloudypix_inmask": {
-        "long_name": "percentage of cloudy pixels inside the lake mask",
+    "boa_add_offset": {
+        "long_name": "BOA additive offset for raw->surface-reflectance "
+                     "conversion: surface_reflectance = (DN + boa_add_offset)/"
+                     "quantification_value",
         "units": "1",
     },
 }
@@ -248,6 +298,49 @@ def finalize_cf(
         except Exception:
             pass
 
+    # --- CF auxiliary coordinate variables for the labelled `band` axis ---
+    # `band` itself is the numeric dimension coordinate; the short names and
+    # per-band metadata are auxiliary coordinate variables (CF §5/§6 labels
+    # pattern). Promote them to coords and declare them via the explicit
+    # `coordinates` encoding on every band-spanning data var, so the file is
+    # self-describing for any CF tool and they round-trip as coordinates
+    # (not stray data variables) rather than relying on xarray implicit
+    # behaviour through the multi-write pipeline.
+    _BAND_AUX = ("band_name", "common_name", "title",
+                 "center_wavelength", "full_width_half_max", "gsd")
+    band_aux = [v for v in _BAND_AUX
+                if v in ds.variables and tuple(ds[v].dims) == ("band",)]
+    if band_aux:
+        to_set = [v for v in band_aux if v not in ds.coords]
+        if to_set:
+            ds = ds.set_coords(to_set)
+        if "center_wavelength" in band_aux:
+            ds["center_wavelength"].attrs.setdefault(
+                "standard_name", "sensor_band_central_radiation_wavelength")
+        coord_attr = " ".join(band_aux)
+        for vname, v in ds.data_vars.items():
+            if "band" in v.dims:
+                v.encoding["coordinates"] = coord_attr
+
+    return ds
+
+
+_CF_ATTR_BAD = re.compile(r"[^0-9A-Za-z_]")
+
+def _cf_sanitise_attr_names(ds):
+    """CF-1.8 §2.3: attribute names must start with a letter and contain only
+    letters/digits/underscores. Rewrites global attr names (``proj:bbox`` ->
+    ``proj_bbox``, ``s2:mgrs_tile`` -> ``s2_mgrs_tile``). Last-wins on the
+    rare collision; nothing here collides in practice.
+    """
+    fixed = {}
+    for k, v in list(ds.attrs.items()):
+        nk = _CF_ATTR_BAD.sub("_", k)
+        if not nk or not (nk[0].isalpha() or nk[0] == "_"):
+            nk = "x_" + nk
+        fixed[nk] = v
+    ds.attrs.clear()
+    ds.attrs.update(fixed)
     return ds
 
 
@@ -287,6 +380,12 @@ def write_netcdf(
         ds = finalize_cf(ds, spatial_vars=spatial_vars,
                          history_action=history_action)
 
+    # Variable-level attrs: scrub stackstac's non-serializable objects
+    # (RasterSpec under 'spec', Affine under 'transform') without touching
+    # valid array attrs like flag_values.
+    ds = _scrub_var_attrs(ds, drop=drop_attrs)
+    ds = _cf_sanitise_attr_names(ds)
+
     # Encoding: zlib for spatial vars, CF-standard for time.
     enc = {}
     for vname, v in ds.data_vars.items():
@@ -294,6 +393,18 @@ def write_netcdf(
             enc[vname] = dict(zlib=True, complevel=4)
             if np.issubdtype(v.dtype, np.floating):
                 enc[vname]["dtype"] = "float32"
+            # Preserve a declared integer no-data sentinel (e.g. the uint8
+            # water_mask_ndwi _FillValue=255) so CF missing-data decodes to
+            # NaN on read, exactly like the float reflectance/p_water NaNs.
+            fv = v.encoding.get("_FillValue", v.attrs.get("_FillValue"))
+            if fv is not None:
+                enc[vname]["_FillValue"] = fv
+    # CF-1.8 §2.2: the netCDF string (vlen) type is not allowed. Force every
+    # string variable/coord to a fixed-width CHARACTER array (adds a
+    # string-length dim) instead of NC_STRING.
+    for vname, v in ds.variables.items():
+        if v.dtype.kind in ("U", "S", "O"):
+            enc.setdefault(vname, {})["dtype"] = "S1"
     if "time" in ds.variables:
         enc["time"] = dict(units="days since 1970-01-01", calendar="standard")
     if encoding:

--- a/sat_tile_stack/stack.py
+++ b/sat_tile_stack/stack.py
@@ -8,6 +8,8 @@ Element84 Earth Search).
 Supports any STAC collection: Sentinel-2, Sentinel-1, Landsat, etc.
 """
 
+import warnings
+
 import numpy as np
 import pandas as pd
 import xarray as xr
@@ -31,7 +33,113 @@ from .bounds import (
     pctnanpix_inmask,
     pctcloudypix_inmask,
 )
-from .utils import combo_scaler, cloud_pix_mask
+from .utils import combo_scaler, cloud_pix_mask, SCL_CLOUDY_CLASSES
+
+# The only non-spectral asset the ESSD build fetches. Pulled to derive
+# `cloud_mask`, then dropped from `reflectance` (it is a classification
+# layer, not surface reflectance).
+NONSPECTRAL_ASSETS = {"SCL"}
+
+# Sentinel-2 L2A quantification value: surface_reflectance = (DN + offset)/QV.
+# Stored in the dataset so the conversion is recoverable from the file alone.
+S2_QUANTIFICATION_VALUE = 10000
+
+
+def _boa_add_offset(item, band_names):
+    """BOA additive offset for a STAC item's reflectance assets.
+
+    Sentinel-2 L2A processing baseline >= 04.00 stores DN shifted by -1000;
+    surface_reflectance = (DN + boa_add_offset) / quantification_value. The
+    offset is product metadata (set by ESA's processing-software version),
+    so it is read from the item rather than assumed. Falls back to the
+    processing-baseline rule when explicit raster:bands metadata is absent.
+    """
+    for b in band_names:
+        if b in NONSPECTRAL_ASSETS:
+            continue
+        asset = item.assets.get(b)
+        if asset is None:
+            continue
+        rb = asset.extra_fields.get("raster:bands")
+        if rb and isinstance(rb, list) and rb and "offset" in rb[0]:
+            try:
+                return float(rb[0]["offset"])
+            except (TypeError, ValueError):
+                pass
+        break
+    bl = str(item.properties.get("s2:processing_baseline", "")).strip()
+    try:
+        return -1000.0 if float(bl) >= 4.0 else 0.0
+    except ValueError:
+        return 0.0
+
+
+# Per-band STAC metadata we keep as tidy band-indexed coords (units + dtype
+# normalized so they survive as coords rather than being flattened to attrs).
+_BAND_META_NUMERIC = {
+    "gsd": ("m", "nominal ground sample distance"),
+    "center_wavelength": ("um", "band center wavelength"),
+    "full_width_half_max": ("um", "band full width at half maximum"),
+}
+_BAND_META_STR = {
+    "common_name": "STAC common band name",
+    "title": "STAC band title",
+}
+
+
+def _tidy_coords(ds, epsg):
+    """Trim stackstac's coordinate clutter to a clean CF coordinate set.
+
+    stackstac attaches every STAC item property as a coordinate. Keep:
+    dimension coords (band/x/y/time), the per-band metadata, and the
+    time-indexed provenance/QA. Demote every *scalar* item-property coord
+    (s2:*, proj:*, epsg, instruments, ...) to a global attribute and drop it
+    as a coordinate — they describe the acquisition, not an axis, and CF does
+    not want them as coordinate variables. Per-band metadata dtypes/units are
+    normalized so they persist as coords (object dtype would otherwise be
+    yanked into attrs on write).
+
+    CF-1.8: a coordinate variable must be numeric & monotonic, so the
+    string-labelled ``band`` axis is converted to an integer index and the
+    short names ('B04'...) move to an auxiliary ``band_name`` coordinate.
+    """
+    if "band" in ds.coords and ds["band"].dtype.kind in ("U", "S", "O"):
+        names = np.array([str(b) for b in ds["band"].values])
+        ds = ds.assign_coords(band=np.arange(names.size, dtype="int32"))
+        ds = ds.assign_coords(band_name=("band", names))
+        ds["band"].attrs.update(long_name="spectral band index", units="1")
+        ds["band_name"].attrs.setdefault(
+            "long_name", "Sentinel-2 band short name")
+
+    for c in list(ds.coords):
+        if c in ("band", "x", "y", "time"):
+            continue
+        dims = ds[c].dims
+        if dims == ("band",):
+            if c in _BAND_META_NUMERIC:
+                units, ln = _BAND_META_NUMERIC[c]
+                ds[c] = ds[c].astype("float64")
+                ds[c].attrs.update(units=units, long_name=ln)
+            elif c in _BAND_META_STR:
+                ds[c] = ds[c].astype(str)
+                ds[c].attrs.setdefault("long_name", _BAND_META_STR[c])
+            continue
+        if dims == ("time",):
+            continue  # eo_cloud_cover / pct_nans / processing_baseline / boa_add_offset
+        if dims == ():
+            val = ds[c].values
+            try:
+                val = val.item()
+            except (ValueError, AttributeError):
+                pass
+            if isinstance(val, set):
+                val = sorted(val)
+            ds.attrs.setdefault(c, val)
+            ds = ds.reset_coords(c, drop=True)
+    # Authoritative CRS hint for finalize_cf's grid_mapping (set after the
+    # `epsg` scalar coord is demoted, so it can't be lost).
+    ds.attrs.setdefault("crs", f"EPSG:{epsg}")
+    return ds
 
 
 def sattile_stack(
@@ -119,14 +227,18 @@ def sattile_stack(
 
     Returns
     -------
-    xarray.DataArray
-        DataArray of shape (time, band, tile_size, tile_size). Coordinates
-        include:
-          - time: resampled steps over `time_range` at the given `cadence`
-          - band: the requested `band_names`
-          - y, x: projected coordinates of the tile
-          - eo_cloud_cover: cloud cover % (if available in collection metadata)
-          - pct_nans: percent of tile that is NaNs
+    xarray.Dataset
+        Dataset with data variables:
+          - reflectance (time, band, y, x): spectral bands only (SCL excluded),
+            raw L2A DN, float32. NOT normalized.
+          - cloud_mask (time, y, x): uint8 SCL-derived cloud flag
+            (0=clear, 1=cloudy), present when 'SCL' is in `band_names`.
+        Coordinates include time, band (spectral), y, x, eo_cloud_cover,
+        pct_nans, and the per-timestep processing provenance
+        `processing_baseline` and `boa_add_offset` (the raw->surface-
+        reflectance recipe; see `reflectance` attrs). The legacy `cloudmask`
+        method arg is retained for signature compatibility but the cloud
+        mask is always SCL-derived; `mask` is ignored (see warning).
 
     Notes
     -----
@@ -197,25 +309,44 @@ def sattile_stack(
     nodata_mask = (stack == 0).all(dim="band")
     stack = stack.where(~nodata_mask)
 
-    # Resample to requested cadence
+    # Split spectral reflectance from the SCL classification BEFORE resampling.
+    # Spectral bands are continuous and may be aggregated; SCL is categorical
+    # (class codes) so averaging it is meaningless — it is resampled with a
+    # categorical-safe 'first' regardless of `aggregation`. This is a
+    # deliberate correctness fix over the legacy single-array path, where a
+    # mean-resampled SCL could produce fractional codes that match no class.
+    spectral_names = [b for b in band_names if b not in NONSPECTRAL_ASSETS]
+    has_scl = "SCL" in band_names
+    spec = stack.sel(band=spectral_names)
+    scl = stack.sel(band="SCL") if has_scl else None
+
+    # Resample spectral reflectance to requested cadence
     start, end = time_range.split("/")
     full_steps = pd.date_range(start, end, freq=cadence)
 
     if aggregation == "mean":
-        stack_resampled = stack.resample(time=cadence).mean("time", keep_attrs=True)
+        spec_res = spec.resample(time=cadence).mean("time", keep_attrs=True)
     elif aggregation == "nearest":
-        stack_resampled = stack.reindex(time=full_steps, method="nearest", tolerance=cadence)
+        spec_res = spec.reindex(time=full_steps, method="nearest", tolerance=cadence)
     elif aggregation == "first":
-        stack_resampled = stack.resample(time=cadence).first(keep_attrs=True)
+        spec_res = spec.resample(time=cadence).first(keep_attrs=True)
     elif aggregation == "last":
-        stack_resampled = stack.resample(time=cadence).last(keep_attrs=True)
+        spec_res = spec.resample(time=cadence).last(keep_attrs=True)
     else:
         raise ValueError(
             f"Invalid aggregation '{aggregation}'. "
             f"Supported: 'mean', 'nearest', 'first', 'last'"
         )
 
-    stack_resampled = stack_resampled.reindex(time=full_steps, fill_value=np.nan)
+    spec_res = spec_res.reindex(time=full_steps, fill_value=np.nan)
+    stack_resampled = spec_res
+
+    # Resample SCL categorically (first observation in each cadence bin).
+    if scl is not None:
+        scl_res = scl.resample(time=cadence).first(keep_attrs=True)
+        scl_res = scl_res.reindex(time=full_steps, fill_value=np.nan)
+    else:
+        scl_res = None
 
     # Extract cloud cover metadata if available
     if items and "eo:cloud_cover" in items[0].properties:
@@ -227,6 +358,42 @@ def sattile_stack(
         daily_cc = cc_da.resample(time=cadence).max()
         daily_cc = daily_cc.reindex(time=full_steps, fill_value=np.nan)
         stack_resampled = stack_resampled.assign_coords(eo_cloud_cover=daily_cc)
+
+    # --- Per-timestep Sentinel-2 processing provenance ---
+    # `processing_baseline` (ESA software version) and `boa_add_offset` travel
+    # with the *product*, not the acquisition date. Recorded per original scene
+    # and aligned onto the resampled timeline so the raw->reflectance recipe
+    # (surface_reflectance = (DN + boa_add_offset) / quantification_value) is
+    # recoverable from the file alone. Categorical-safe 'first' per cadence bin.
+    baselines = np.array(
+        [str(it.properties.get("s2:processing_baseline", "")) for it in items],
+        dtype=object,
+    )
+    offsets = np.array(
+        [_boa_add_offset(it, band_names) for it in items], dtype="float64"
+    )
+    bl_da = xr.DataArray(baselines, coords={"time": stack.time}, dims=["time"])
+    off_da = xr.DataArray(offsets, coords={"time": stack.time}, dims=["time"])
+    bl_daily = bl_da.resample(time=cadence).first().reindex(
+        time=full_steps, fill_value=""
+    )
+    # Empty resample bins yield NaN (float) even for an object/string array;
+    # normalize the baseline coord to clean strings ("" == no observation) so
+    # it is both NetCDF-writable and safely sortable downstream.
+    # Fixed-width unicode (NOT object): an object-dtype coord is demoted to a
+    # global attr by io.sanitise_dataset, which would silently drop
+    # processing_baseline as a per-timestep coordinate.
+    bl_clean = np.array(
+        [b if isinstance(b, str) else "" for b in bl_daily.values],
+        dtype="<U16",
+    )
+    bl_daily = bl_daily.copy(data=bl_clean)
+    off_daily = off_da.resample(time=cadence).first().reindex(
+        time=full_steps, fill_value=np.nan
+    )
+    stack_resampled = stack_resampled.assign_coords(
+        processing_baseline=bl_daily, boa_add_offset=off_daily
+    )
 
     # Apply normalization if requested
     if normalize:
@@ -243,57 +410,119 @@ def sattile_stack(
             keep_attrs=True,
         )
 
-    # Crop tiles to desired size
+    if mask is not None:
+        warnings.warn(
+            "`mask` is ignored by sattile_stack in the v2 schema. The per-lake "
+            "footprint (`lake_boundary`) is co-registered separately via "
+            "coregister.add_static_polygon (Dunmire 2021).",
+            stacklevel=2,
+        )
+
+    # Crop tiles to desired size (reflectance + SCL share the same grid)
     buffer = tile_size * pix_res / 2  # [m]
     x_utm, y_utm = pyproj.Proj(stack.crs)(*centroid)
-    timestack = stack_resampled.loc[
+    reflectance_ts = stack_resampled.loc[
         ..., y_utm + buffer : y_utm - buffer, x_utm - buffer : x_utm + buffer
-    ]
+    ].astype("float32")
 
-    # Track percent of pixels that are NaN
-    nan_counts = timestack.isnull().sum(dim=("band", "y", "x"))
-    total = len(band_names) * tile_size * tile_size
+    scl_ts = None
+    if scl_res is not None:
+        scl_ts = scl_res.loc[
+            ..., y_utm + buffer : y_utm - buffer, x_utm - buffer : x_utm + buffer
+        ]
+
+    # Track percent of NaN pixels in the spectral tile
+    nan_counts = reflectance_ts.isnull().sum(dim=("band", "y", "x"))
+    total = len(spectral_names) * tile_size * tile_size
     pct_nans = (nan_counts / total) * 100
-    timestack = timestack.assign_coords(pct_nans=("time", pct_nans.values))
+    reflectance_ts = reflectance_ts.assign_coords(pct_nans=("time", pct_nans.values))
 
-    # Compute cloud mask if requested
-    if cloudmask is not False:
-        if callable(cloudmask):
-            cloud_mask_da = cloudmask(timestack)
-        elif isinstance(cloudmask, str):
-            cloud_mask_da = cloud_pix_mask(timestack, method=cloudmask)
-        else:
-            raise ValueError(
-                f"cloudmask must be False, a method name string, or a callable. "
-                f"Got: {type(cloudmask)}"
-            )
-        cloud_mask_da = cloud_mask_da.expand_dims(dim={"band": ["cloudmask"]})
-        timestack = xr.concat([timestack, cloud_mask_da], dim="band")
+    # Assemble the CF-style Dataset: reflectance (spectral) + cloud_mask (SCL).
+    ds = xr.Dataset(
+        data_vars={"reflectance": reflectance_ts},
+        attrs=dict(stack_resampled.attrs),
+    )
+    if scl_ts is not None:
+        cloud_mask = scl_ts.isin(SCL_CLOUDY_CLASSES).astype("uint8")
+        cloud_mask = cloud_mask.drop_vars("band", errors="ignore")
+        cloud_mask.attrs = {
+            "long_name": "Sentinel-2 SCL-derived cloud flag",
+            "flag_values": np.array([0, 1], dtype="uint8"),
+            "flag_meanings": "clear cloudy",
+            "source": (
+                "Sentinel-2 L2A Scene Classification Layer (SCL); cloudy = SCL "
+                f"classes {tuple(int(c) for c in SCL_CLOUDY_CLASSES)} "
+                "(3=cloud_shadow, 8=cloud_medium_prob, 9=cloud_high_prob, "
+                "10=thin_cirrus). Categorical 'first' resampling per cadence "
+                "bin. Days with no observation are 0 (clear); consult "
+                "`pct_nans` / reflectance NaNs to distinguish no-data."
+            ),
+        }
+        ds["cloud_mask"] = cloud_mask
 
-    # Generate spatial mask if provided
-    if mask is not None:
-        satmask = sat_mask_array(timestack, mask, feature_id=None)
-        timestack = xr.concat([timestack, satmask], dim="band")
+    # Demote stackstac's scalar item-property coords to global attrs; keep a
+    # clean CF coordinate set (band/x/y/time + band metadata + time provenance).
+    ds = _tidy_coords(ds, epsg)
 
-    # Track percent of pixels within mask that are NaNs and cloudy
-    if mask is not None:
-        pct_nan = pctnanpix_inmask(timestack)
-        timestack = timestack.assign_coords(pctnanpix_inmask=("time", pct_nan.data))
-        if cloudmask:
-            pct_cloudy = pctcloudypix_inmask(timestack)
-            timestack = timestack.assign_coords(
-                pctcloudypix_inmask=("time", pct_cloudy.data)
-            )
+    # Raw->surface-reflectance recipe, recoverable from the file alone.
+    ds["reflectance"].attrs.setdefault(
+        "long_name", "Sentinel-2 L2A raw surface-reflectance digital numbers"
+    )
+    ds["reflectance"].attrs.setdefault("units", "1")
+    ds["reflectance"].attrs.setdefault(
+        "comment",
+        "Raw Sentinel-2 L2A (BOA) digital numbers as delivered by Microsoft "
+        "Planetary Computer; NOT normalized. To convert to surface "
+        "reflectance: surface_reflectance = (DN + boa_add_offset) / "
+        f"quantification_value, with quantification_value = "
+        f"{S2_QUANTIFICATION_VALUE}. `boa_add_offset` and `processing_baseline` "
+        "are provided per timestep. Normalization is a downstream (ML) choice.",
+    )
+    ds.attrs["s2:quantification_value"] = S2_QUANTIFICATION_VALUE
 
-    # Convert to float32
-    timestack = timestack.astype("float32")
+    # Mixed-baseline checkpoint: surface it in attrs (stdout is suppressed in
+    # batch builds) and warn for interactive callers.
+    fin = off_daily.values[np.isfinite(off_daily.values.astype("float64"))] \
+        if off_daily.size else np.array([])
+    uniq_off = sorted({float(v) for v in fin})
+    uniq_bl = sorted({str(b) for b in bl_daily.values.tolist()
+                      if isinstance(b, str) and b})
+    ds.attrs["s2:processing_baseline_values"] = uniq_bl
+    ds.attrs["boa_add_offset_values"] = uniq_off
+    mixed = len(uniq_off) > 1
+    ds.attrs["mixed_processing_baseline"] = int(mixed)  # netCDF has no bool
+    if mixed:
+        warnings.warn(
+            f"Stack mixes Sentinel-2 processing baselines {uniq_bl} "
+            f"(boa_add_offset {uniq_off}). Raw DN are stored unaltered; "
+            "per-timestep `boa_add_offset` must be applied before comparing "
+            "values across the time series.",
+            stacklevel=2,
+        )
 
-    # Pull stack into memory if requested
     if pull_to_mem:
-        print(f"Pulling stack into memory, shape: {timestack.shape}")
+        print(
+            f"Pulling stack into memory: {len(items)} scenes -> "
+            f"vars {list(ds.data_vars)}, dims {dict(ds.sizes)} "
+            f"(this is network/IO-bound; minutes per full-season 512^2 lake)",
+            flush=True,
+        )
         with dask.diagnostics.ProgressBar():
-            timestack_mem = timestack.compute()
-        print(f"Stack loaded, shape: {timestack_mem.shape}")
-        return timestack_mem
-    else:
-        return timestack
+            ds = ds.compute()
+        # Distribution sanity gate (catches gross scale/offset corruption
+        # before a full Sherlock run). Raw S2 DN of glacial scenes sit well
+        # within (0, 20000); a wildly out-of-range median means something
+        # upstream is wrong.
+        rv = ds["reflectance"].values
+        finite = np.isfinite(rv)
+        if finite.any():
+            med = float(np.nanmedian(rv[finite]))
+            if not (0.0 < med < 20000.0):
+                raise ValueError(
+                    f"reflectance median DN {med:.1f} outside plausible "
+                    f"(0, 20000) — suspect scale/offset corruption "
+                    f"(baselines={uniq_bl}, offsets={uniq_off})."
+                )
+        print(f"Stack loaded, vars: {list(ds.data_vars)}", flush=True)
+
+    return ds

--- a/sat_tile_stack/utils.py
+++ b/sat_tile_stack/utils.py
@@ -9,6 +9,21 @@ import numpy as np
 
 CLOUD_METHODS = ["williamson", "scl"]
 
+# Sentinel-2 Scene Classification Layer (SCL) class codes treated as "cloudy"
+# for the ESSD `cloud_mask` data variable. This is the single source of truth
+# for the SCL cloud definition; `stack.py` and the `cloud_mask` variable's
+# `source` attribute both reference it so the dataset's documented semantics
+# can never drift from the code.
+#
+#   3  = cloud shadow
+#   8  = cloud, medium probability
+#   9  = cloud, high probability
+#   10 = thin cirrus
+#
+# (SCL also defines 0=no_data, 1=saturated/defective, 2=dark area, 4=vegetation,
+#  5=bare soil, 6=water, 7=unclassified, 11=snow/ice — none flagged as cloud.)
+SCL_CLOUDY_CLASSES = (3, 8, 9, 10)
+
 
 def cloud_pix_mask(timestack, method="williamson"):
     """


### PR DESCRIPTION
One reproducible CF-1.8 pipeline, single `.nc`/lake, validated by
`cfchecker` (errors=0).

Schema: `reflectance` · `cloud_mask` · `water_mask_ndwi` · `lake_boundary` ·
`p_water` · `crs`.

- `stack.py`: STAC→CF Dataset (+B12, SCL→cloud_mask)
- `coregister.py`: +`add_ndwi_from_stack` (NDWI from own B02/B04)
- `io.py`: CF finalize; fix `sanitise_dataset` dropping string coords
- new `cf_check.py` / `sts-cf-check`
- `build_stacks.py --coregister` end-to-end, resume-safe
- deps +`zarr>=3` +`cfchecker`

Breaking: `band` is an int index (use `band_name`); `p_water` is a fraction.